### PR TITLE
fix segfault in envp and argv loops

### DIFF
--- a/src/programs.c
+++ b/src/programs.c
@@ -1004,7 +1004,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_exec_tc_argv,
 
     // this number was arrived at experimentally, increasing it will result in too many
     // instructions for older kernels
-    READ_LOOP_N(argv, TE_COMMAND_LINE, 7);
+    READ_LOOP_N(argv, TE_COMMAND_LINE, 6);
 
     bpf_map_update_elem(&read_flush_index, &index, &ii, BPF_ANY);
 
@@ -1065,7 +1065,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_exec_tc_envp,
 
     // this number was arrived at experimentally, increasing it will result in too many
     // instructions for older kernels
-    READ_LOOP_N(envp, TE_ENVIRONMENT, 7);
+    READ_LOOP_N(envp, TE_ENVIRONMENT, 6);
 
     bpf_map_update_elem(&read_flush_index, &index, &ii, BPF_ANY);
 

--- a/src/types.h
+++ b/src/types.h
@@ -7,7 +7,12 @@
 #define MAX_ADDRESSES 16
 #define TRUE 1
 #define FALSE 0
-#define VALUE_SIZE 128
+
+/*
+ * This number was determined experimentally, setting it higher will exceed
+ * the BPF 512 byte stack limit.
+ */
+#define VALUE_SIZE 176
 
 typedef enum
 {


### PR DESCRIPTION
When we loop through envp and argv, we get a new `ev` off the telemetry stack. This can reset the `telemetry_event_type_t` to the wrong type, and fill the event with garbage data that we need to overwrite. This PR moves setting event fields back into the loop, and adds some clarifying comments on weird things we need to do to please the verifier.