### PR TITLE
root namespace pid

### DIFF
--- a/src/offsets.h
+++ b/src/offsets.h
@@ -10,6 +10,9 @@ const u64 CRC_TASK_STRUCT_REAL_PARENT = 0x940b92aaad4c5437;
 /* CRC64 of task_struct->pid */
 const u64 CRC_TASK_STRUCT_PID = 0xc713ffcffcd1cc3c;
 
+/* CRC64 of task_struct->tgid */
+const u64 CRC_TASK_STRUCT_TGID = 0x68bd2d49cb6f7dd5;
+
 /* CRC64 of task_struct->loginuid */
 const u64 CRC_TASK_STRUCT_LOGINUID = 0x9951a3e4f7757060;
 

--- a/src/programs.c
+++ b/src/programs.c
@@ -2165,8 +2165,12 @@ int kretprobe__ret_sys_clone3(struct pt_regs *ctx)
     return exit_clone3(ctx);
 }
 
-SEC("kprobe/uprobe_copy_process")
-int kprobe__uprobe_copy_process(struct pt_regs *ctx)
+// This probe can generically read the pid from a task_struct at any point
+// where the first argument is a pointer to a task_struct, the event emit
+// is a RETCODE with the correct PID, intended for use with tracing fork,
+// clone, etc.
+SEC("kprobe/read_pid_task_struct")
+int kprobe__read_pid_task_struct(struct pt_regs *ctx)
 {
     // get new current
     void *ts = (void *)PT_REGS_PARM1(ctx);

--- a/src/programs.c
+++ b/src/programs.c
@@ -2197,6 +2197,9 @@ int kprobe__read_pid_task_struct(struct pt_regs *ctx)
     u64 ppid_tgid = (u64) ptgid << 32 | ppid;
     u64 *id = bpf_map_lookup_elem(&telemetry_ids, &ppid_tgid);
 
+    if (!id)
+        return -1;
+
     // send event with ID
     ptelemetry_event_t ev = &(telemetry_event_t){
         .id = 0,
@@ -2207,9 +2210,6 @@ int kprobe__read_pid_task_struct(struct pt_regs *ctx)
                 .truncated = FALSE,
                 },
         };
-
-    if (!id)
-        return -1;
 
     ev->id = *id;
     bpf_map_delete_elem(&telemetry_ids, &ppid_tgid);

--- a/src/programs.c
+++ b/src/programs.c
@@ -2165,11 +2165,11 @@ int kretprobe__ret_sys_clone3(struct pt_regs *ctx)
     return exit_clone3(ctx);
 }
 
-SEC("kretprobe/ret_copy_process")
-int kretprobe__ret_copy_process(struct pt_regs *ctx)
+SEC("kprobe/uprobe_copy_process")
+int kprobe__uprobe_copy_process(struct pt_regs *ctx)
 {
     // get new current
-    void *ts = (void *)PT_REGS_RC(ctx);
+    void *ts = (void *)PT_REGS_PARM1(ctx);
 
     // get the true pid
     u32 pid = 0;

--- a/src/programs.c
+++ b/src/programs.c
@@ -1312,7 +1312,6 @@ static __always_inline int exit_exec(struct pt_regs *__ctx, u32 i_rdev, u64 i_in
     ev->id = *id;
     ev->done = TRUE;
     ev->telemetry_type = TE_RETCODE;
-    ev->u.r.pid_tgid = pid_tgid;
     ev->u.r.retcode = (u32)PT_REGS_RC(__ctx);
     push_telemetry_event(__ctx, ev);
 
@@ -2214,7 +2213,6 @@ int kprobe__read_pid_task_struct(struct pt_regs *ctx)
     ev->id = *id;
     bpf_map_delete_elem(&telemetry_ids, &ppid_tgid);
     ev->telemetry_type = TE_RETCODE;
-    ev->u.r.retcode = 0;
     ev->u.r.pid_tgid = pid_tgid;
     push_telemetry_event(ctx, ev);
     return 0;
@@ -2340,7 +2338,6 @@ static __always_inline int exit_unshare(struct pt_regs *ctx)
     bpf_map_delete_elem(&telemetry_ids, &pid_tgid);
 
     ev->telemetry_type = TE_RETCODE;
-    ev->u.r.pid_tgid = pid_tgid;
     ev->u.r.retcode = (u32)PT_REGS_RC(ctx);
     push_telemetry_event(ctx, ev);
 
@@ -2438,7 +2435,6 @@ static __always_inline int exit_exit(struct pt_regs *ctx)
     bpf_map_delete_elem(&telemetry_ids, &pid_tgid);
 
     ev->telemetry_type = TE_RETCODE;
-    ev->u.r.pid_tgid = pid_tgid;
     ev->u.r.retcode = (u32)PT_REGS_RC(ctx);
     push_telemetry_event(ctx, ev);
 

--- a/src/programs.c
+++ b/src/programs.c
@@ -2168,8 +2168,6 @@ int kretprobe__ret_sys_clone3(struct pt_regs *ctx)
 SEC("kretprobe/ret_copy_process")
 int kretprobe__ret_copy_process(struct pt_regs *ctx)
 {
-    bpf_printk("ret_copy_process firing\n");
-
     // get new current
     void *ts = (void *)PT_REGS_RC(ctx);
 
@@ -2179,7 +2177,6 @@ int kretprobe__ret_copy_process(struct pt_regs *ctx)
     read_value(ts, CRC_TASK_STRUCT_PID, &pid, sizeof(pid));
     read_value(ts, CRC_TASK_STRUCT_TGID, &tgid, sizeof(tgid));
     u64 pid_tgid = (u64) tgid << 32 | pid;
-    bpf_printk("current: %d\n", pid_tgid >> 32);
 
     // get the real parent
     read_value(ts, CRC_TASK_STRUCT_REAL_PARENT, &ts, sizeof(ts));
@@ -2192,12 +2189,9 @@ int kretprobe__ret_copy_process(struct pt_regs *ctx)
     // ts->real_parent->tgid
     read_value(ts, CRC_TASK_STRUCT_TGID, &ptgid, sizeof(ptgid));
 
-    bpf_printk("parent: %d\n", ptgid);
-
     // combine to find ID, get ID
     u64 ppid_tgid = (u64) ptgid << 32 | ppid;
     u64 *id = bpf_map_lookup_elem(&telemetry_ids, &ppid_tgid);
-    bpf_printk("id: %d\n", id);
 
     // send event with ID
     ptelemetry_event_t ev = &(telemetry_event_t){

--- a/src/types.h
+++ b/src/types.h
@@ -314,7 +314,7 @@ typedef struct
             char value[VALUE_SIZE];
             char truncated;
         } v;
-        struct
+        union
         {
             u64 pid_tgid;
             u64 retcode;

--- a/src/types.h
+++ b/src/types.h
@@ -314,7 +314,11 @@ typedef struct
             char value[VALUE_SIZE];
             char truncated;
         } v;
-        u64 retcode;
+        struct
+        {
+            u64 pid_tgid;
+            u64 retcode;
+        } r;
     } u;
 } telemetry_event_t, *ptelemetry_event_t;
 


### PR DESCRIPTION
We were previously returning the return code from a `fork` family syscall as-is, which gives the child PID in its namespace. This removes several `TE_RETCODE` events for `fork` family calls and replaces them with a single `TE_RETCODE` which contains the child's PID in the root namespace, which we get from `uprobe_copy_process`. This function is called towards the end of `copy_process` and has the child's `task_struct` as its first argument. It appears to be consistently exported in the distros I've tested and is available from 4.11 onwards. `copy_process` and `klp_copy_process` were two other candidates, but were not available on all systems.