### PR TITLE
get exits more reliably and get deeper nested paths

### DIFF
--- a/src/process-events.c
+++ b/src/process-events.c
@@ -34,6 +34,15 @@ struct bpf_map_def SEC("maps/read_flush_index") read_flush_index = {
     .namespace = "",
 };
 
+struct bpf_map_def SEC("maps/read_path_skip") read_path_skip = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(u32),
+    .value_size = sizeof(u64),
+    .max_entries = 1,
+    .pinning = 0,
+    .namespace= "",
+};
+
 struct bpf_map_def SEC("maps/clone_info_store") clone_info_store = {
     .type = BPF_MAP_TYPE_PERCPU_ARRAY,
     .key_size = sizeof(u32),
@@ -243,6 +252,17 @@ static __always_inline void push_telemetry_event(struct pt_regs *ctx, ptelemetry
 
 #define READ_VALUE_N(EV, T, S, N) REPEAT_##N(READ_VALUE(EV, T, S);)
 
+#define SKIP_PATH                                       \
+    if (skipped >= to_skip)                             \
+        goto Send;                                      \
+    /* Skip to the parent directory */                  \
+    bpf_probe_read(&ptr, sizeof(ptr), ptr + parent);    \
+    skipped += 1;                                       \
+    if (!ptr)                                           \
+        goto Send;                                      \
+
+#define SKIP_PATH_N(N) REPEAT_##N(SKIP_PATH;)
+
 #define SEND_PATH                                                           \
     ev->id = id;                                                            \
     ev->done = FALSE;                                                       \
@@ -272,6 +292,7 @@ static __always_inline void push_telemetry_event(struct pt_regs *ctx, ptelemetry
         }                                                                   \
         /* we're done here, follow the pointer */                           \
         bpf_probe_read(&ptr, sizeof(ptr), ptr + parent);                    \
+        to_skip += 1;                                                       \
         if (!ptr)                                                           \
             goto Skip;                                                      \
         if (br == '/')                                                      \
@@ -343,7 +364,16 @@ static __always_inline ptelemetry_event_t enter_exec_4_11(syscall_pattern_type_t
     u32 count = 0;
     char br = 0;
 
+    // reuse count as idx and value to save stack space
+    bpf_map_update_elem(&read_path_skip, &count, &count, BPF_ANY);
+
 Pwd:;
+
+    // the verifier complains if these are instantiated before the Pwd:; label
+    u64 to_skip = 0;
+    u64 skipped = 0;
+
+    // since index will start at zero, we can use it here
     u64 offset = 0;
     void *ptr = (void *)bpf_get_current_task();
     if (read_value(ptr, CRC_TASK_STRUCT_FS, &ptr, sizeof(ptr)) < 0)
@@ -367,10 +397,24 @@ Pwd:;
     SET_OFFSET(CRC_DENTRY_D_PARENT);
     u32 parent = *(u32 *)offset; // offset of d_parent
 
-    SEND_PATH_N(9);
-    bpf_tail_call(ctx, &tail_call_table, SYS_EXECVE_4_8);
+    u64 _to_skip = (u64)bpf_map_lookup_elem(&read_path_skip, &to_skip);
+    if (_to_skip) {
+        __builtin_memcpy(&to_skip, (void*)_to_skip, sizeof(u64));
+        SKIP_PATH_N(100);
+    }
+
+Send:
+    SEND_PATH_N(10);
+
+    // update to_skip, reuse skipped as index by resetting it
+    skipped = 0;
+    bpf_map_update_elem(&read_path_skip, &skipped, &to_skip, BPF_ANY);
+    // tail call back in
+    bpf_tail_call(ctx, &tail_call_table, SYS_EXECVE_4_11);
 
 Skip:
+    skipped = 0;
+    bpf_map_delete_elem(&read_path_skip, &skipped);
     ev->id = id;
     return ev;
 }

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -400,7 +400,7 @@ Pwd:;
     u64 _to_skip = (u64)bpf_map_lookup_elem(&read_path_skip, &to_skip);
     if (_to_skip) {
         __builtin_memcpy(&to_skip, (void*)_to_skip, sizeof(u64));
-        SKIP_PATH_N(100);
+        SKIP_PATH_N(150);
     }
 
 Send:

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -1202,24 +1202,14 @@ static __always_inline int enter_exit(syscall_pattern_type_t sp, int status,
 
     ev->id = id;
     ev->done = FALSE;
-    ev->telemetry_type = TE_EXE_PATH;
-    ev->u.v.truncated = FALSE;
-    long count = 0;
-    count = bpf_probe_read_str(&ev->u.v.value, VALUE_SIZE, (void *)exe);
-    if (count == VALUE_SIZE)
-    {
-        ev->u.v.truncated = TRUE;
-    }
-    push_telemetry_event(ctx, ev);
-
-    ev->id = id;
-    ev->done = FALSE;
     ev->telemetry_type = TE_EXIT_STATUS;
     ev->u.exit_status = status;
     push_telemetry_event(ctx, ev);
-    bpf_map_update_elem(&process_ids, &pid_tgid, &id, BPF_ANY);
 
-    bpf_tail_call(ctx, &tail_call_table, RET_SYS_EXIT);
+    ev->id = id;
+    ev->telemetry_type = TE_RETCODE;
+    ev->u.r.retcode = (u32)PT_REGS_RC(ctx);
+    push_telemetry_event(ctx, ev);
 
     return 0;
 }

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -547,7 +547,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_execveat_4_11,
     bpf_tail_call(ctx, &tail_call_table, SYS_EXEC_TC_ARGV);
 
 Skip:
-    return -1;
+    return 0;
 }
 
 SEC("kprobe/sys_execve_4_11")
@@ -582,7 +582,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_execve_4_11,
     bpf_tail_call(ctx, &tail_call_table, SYS_EXEC_TC_ARGV);
 
 Skip:
-    return -1;
+    return 0;
 }
 
 SEC("kprobe/sys_execveat")
@@ -793,7 +793,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_clone_4_8, unsigned long flags, void __user *
     GET_OFFSETS_4_8;
     return enter_clone(SP_CLONE, flags, stack, parent_tid, child_tid, tls, ctx, ppid, luid, exe, length);
 Skip:
-    return -1;
+    return 0;
 }
 
 SEC("kprobe/sys_clone")
@@ -941,7 +941,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_clone3, struct clone_args __user *uargs, size
     GET_OFFSETS_4_8;
     return enter_clone3(SP_CLONE3, uargs, size, ctx, ppid, luid, exe, length);
 Skip:
-    return -1;
+    return 0;
 }
 
 SEC("kretprobe/ret_sys_clone3")
@@ -980,7 +980,7 @@ int kprobe__read_inode_task_struct(struct pt_regs *ctx)
     u64 *id = bpf_map_lookup_elem(&process_ids, &pid_tgid);
 
     if (!id)
-        return -1;
+        return 0;
 
     // prepare event
     ptelemetry_event_t ev = &(telemetry_event_t){
@@ -1051,7 +1051,7 @@ int kprobe__read_pid_task_struct(struct pt_regs *ctx)
     u64 *id = bpf_map_lookup_elem(&process_ids, &ppid_tgid);
 
     if (!id)
-        return -1;
+        return 0;
 
     // send event with ID
     ptelemetry_event_t ev = &(telemetry_event_t){
@@ -1094,7 +1094,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_fork_4_8)
     GET_OFFSETS_4_8;
     return enter_clone(SP_FORK, 0, NULL, NULL, NULL, 0, ctx, ppid, luid, exe, length);
 Skip:
-    return -1;
+    return 0;
 }
 
 SEC("kprobe/sys_vfork_4_8")
@@ -1107,7 +1107,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_vfork_4_8)
     GET_OFFSETS_4_8;
     return enter_clone(SP_VFORK, 0, NULL, NULL, NULL, 0, ctx, ppid, luid, exe, length);
 Skip:
-    return -1;
+    return 0;
 }
 
 SEC("kretprobe/ret_sys_clone")
@@ -1209,7 +1209,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_unshare_4_8, int flags)
     GET_OFFSETS_4_8;
     return enter_unshare(SP_UNSHARE, flags, ctx, ppid, luid, exe, length);
 Skip:
-    return -1;
+    return 0;
 }
 
 SEC("kprobe/sys_unshare")
@@ -1311,10 +1311,10 @@ int BPF_KPROBE_SYSCALL(kprobe__do_exit_4_8, int status)
     u32 length = -1;
     GET_OFFSETS_4_8;
     if (enter_exit(SP_EXIT, status, ctx, ppid, luid, exe, length) < 0)
-        return -1;
+        return 0;
     return exit_exit(ctx);
 Skip:
-    return -1;
+    return 0;
 }
 
 // do_exit probes must call enter_exit() and exit_exit() since do_exit is __no_return
@@ -1326,7 +1326,7 @@ int BPF_KPROBE_SYSCALL(kprobe__do_exit, int status)
     if ((pid_tgid >> 32) ^ (pid_tgid & 0xFFFFFFFF))
         return 0;
     if (enter_exit(SP_EXIT, status, ctx, -1, -1, NULL, -1) < 0)
-        return -1;
+        return 0;
     return exit_exit(ctx);
 }
 
@@ -1345,7 +1345,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_exit_4_8, int status)
     GET_OFFSETS_4_8;
     return enter_exit(SP_EXIT, status, ctx, ppid, luid, exe, length);
 Skip:
-    return -1;
+    return 0;
 }
 
 SEC("kprobe/sys_exit")
@@ -1368,7 +1368,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_exit_group_4_8, int status)
     GET_OFFSETS_4_8;
     return enter_exit(SP_EXITGROUP, status, ctx, ppid, luid, exe, length);
 Skip:
-    return -1;
+    return 0;
 }
 
 SEC("kprobe/sys_exit_group")

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -1202,14 +1202,24 @@ static __always_inline int enter_exit(syscall_pattern_type_t sp, int status,
 
     ev->id = id;
     ev->done = FALSE;
-    ev->telemetry_type = TE_EXIT_STATUS;
-    ev->u.exit_status = status;
+    ev->telemetry_type = TE_EXE_PATH;
+    ev->u.v.truncated = FALSE;
+    long count = 0;
+    count = bpf_probe_read_str(&ev->u.v.value, VALUE_SIZE, (void *)exe);
+    if (count == VALUE_SIZE)
+    {
+        ev->u.v.truncated = TRUE;
+    }
     push_telemetry_event(ctx, ev);
 
     ev->id = id;
-    ev->telemetry_type = TE_RETCODE;
-    ev->u.r.retcode = (u32)PT_REGS_RC(ctx);
+    ev->done = FALSE;
+    ev->telemetry_type = TE_EXIT_STATUS;
+    ev->u.exit_status = status;
     push_telemetry_event(ctx, ev);
+    bpf_map_update_elem(&process_ids, &pid_tgid, &id, BPF_ANY);
+
+    bpf_tail_call(ctx, &tail_call_table, RET_SYS_EXIT);
 
     return 0;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -354,6 +354,8 @@ typedef enum
 {
     SYS_EXECVE_4_8,
     SYS_EXECVEAT_4_8,
+    SYS_EXECVE_4_11,
+    SYS_EXECVEAT_4_11,
     SYS_EXEC_TC_ARGV,
     SYS_EXEC_TC_ENVP,
     RET_SYS_EXECVE,


### PR DESCRIPTION
This updates our probes with the following features:
* get deeper nested paths from process starts
* get inode information more reliably
* capture process exits more reliably