### PR TITLE
Fixing ppid bug

### DIFF
--- a/src/process-events.c
+++ b/src/process-events.c
@@ -148,7 +148,7 @@ struct bpf_map_def SEC("maps/tail_call_table") tail_call_table = {
     if (ts)                                                                                             \
     {                                                                                                   \
         read_value(ts, CRC_TASK_STRUCT_REAL_PARENT, &ptr, sizeof(ptr));                                 \
-        read_value(ptr, CRC_TASK_STRUCT_PID, &ppid, sizeof(ppid));                                      \
+        read_value(ptr, CRC_TASK_STRUCT_TGID, &ppid, sizeof(ppid));                                     \
         read_value(ts, CRC_TASK_STRUCT_LOGINUID, &luid, sizeof(luid));                                  \
         read_value(ts, CRC_TASK_STRUCT_MM, &ptr, sizeof(ptr));                                          \
         read_value(ptr, CRC_MM_STRUCT_EXE_FILE, &ptr, sizeof(ptr));                                     \


### PR DESCRIPTION
This fixes two bugs we were seeing in the consistency checker:

1. We were getting a weird fork that had no parent. This was caused by it trying to send an event before CRC_LOADED was written to. 

2. Sometimes the PPID was off by one. This was caused by us using the PID out of the task_struct instead of the TGID. Everywhere else we use the task_struct's TGID as the "pid" and the task struct PID as the "TID". This is also the way the code red sensor expects it. From user space, when someone asks for "what is my current PID", it is actually the TGID what is returned so this matches that expectation as well: https://elixir.bootlin.com/linux/v4.4.160/source/kernel/sys.c#L832