### PR TITLE
Updated linux kernel header files to 4.11.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:16.04
 
 RUN apt-get update
-RUN apt-get install -y llvm-6.0 clang-6.0 libclang-6.0-dev \
-    linux-headers-4.4.0-98-generic linux-headers-4.10.0-14-generic \
+RUN apt-get install -y llvm-8 clang-8 libclang-8-dev \
+    linux-headers-4.11.0-14-generic linux-headers-4.10.0-14-generic \
     make binutils curl coreutils
 
 WORKDIR /src

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ SRC = src
 SRCS = $(wildcard $(SRC)/*.c)
 OBJS = $(patsubst $(SRC)/%.c,$(SRC)/%,$(SRCS))
 OBJS_WRAPPED = $(OBJS)
-CC = clang-6.0
-LLC = llc-6.0
-OPT = opt-6.0
-LLVM_DIS = llvm-dis-6.0
+CC = clang-8
+LLC = llc-8
+OPT = opt-8
+LLVM_DIS = llvm-dis-8
 CFLAGS += \
 	-D__KERNEL__ \
 	-D__BPF_TRACING__ \
@@ -36,7 +36,7 @@ TARGET = -target aarch64
 else ifeq ($(ARCH),x86_64)
 CFLAGS += -D__ASM_SYSREG_H
 KERNEL_ARCH_NAME = x86
-KERNEL_HEADER_VERSION ?= 4.4.0-98-generic
+KERNEL_HEADER_VERSION ?= 4.11.0-14-generic
 TARGET = -target x86_64
 else
 $(error Unknown architecture $(ARCH))
@@ -76,8 +76,8 @@ endif
 
 depends:
 	apt-get update
-	apt-get install -y llvm-6.0 clang-6.0 libclang-6.0-dev \
-		linux-headers-4.4.0-98-generic linux-headers-4.10.0-14-generic \
+	apt-get install -y llvm-8 clang-8 libclang-8-dev \
+		linux-headers-4.11.0-14-generic linux-headers-4.10.0-14-generic \
 		make binutils curl coreutils gcc
 
 no_wrapper:

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,11 @@ SRC = src
 SRCS = $(wildcard $(SRC)/*.c)
 OBJS = $(patsubst $(SRC)/%.c,$(SRC)/%,$(SRCS))
 OBJS_WRAPPED = $(OBJS)
-CC = clang-8
-LLC = llc-8
-OPT = opt-8
-LLVM_DIS = llvm-dis-8
+CLANG_VER = 8
+CC = clang-$(CLANG_VER)
+LLC = llc-$(CLANG_VER)
+OPT = opt-$(CLANG_VER)
+LLVM_DIS = llvm-dis-$(CLANG_VER)
 CFLAGS += \
 	-D__KERNEL__ \
 	-D__BPF_TRACING__ \
@@ -76,8 +77,8 @@ endif
 
 depends:
 	apt-get update
-	apt-get install -y llvm-8 clang-8 libclang-8-dev \
-		linux-headers-4.11.0-14-generic linux-headers-4.10.0-14-generic \
+	apt-get install -y llvm-$(CLANG_VER) clang-$(CLANG_VER) libclang-$(CLANG_VER)-dev \
+		linux-headers-$(KERNEL_HEADER_VERSION) \
 		make binutils curl coreutils gcc
 
 no_wrapper:


### PR DESCRIPTION
Because of certain eBPF functions that are required our minimum
supported version is 4.11.
Updated build toolchain to v8 instead of v6