### PR TITLE
Filter out failed execs

### DIFF
--- a/src/network-events.c
+++ b/src/network-events.c
@@ -92,7 +92,6 @@ int kretprobe__ret_inet_csk_accept(struct pt_regs *ctx)
 
     // Initialize some of the telemetry event
     ev.id = bpf_get_prandom_u32();
-    ev.done = 0;
     ev.telemetry_type = TE_NETWORK;
     ev.u.network_info.mono_ns = bpf_ktime_get_ns();
 
@@ -151,7 +150,6 @@ int kretprobe__ret___skb_recv_udp(struct pt_regs *ctx)
 
     // Initialize some of the telemetry event
     ev.id = bpf_get_prandom_u32();
-    ev.done = 0;
     ev.telemetry_type = TE_NETWORK;
     ev.u.network_info.protocol_type = IPPROTO_UDP;
     ev.u.network_info.mono_ns = bpf_ktime_get_ns();
@@ -308,7 +306,6 @@ int kretprobe__ret_udp_outgoing(struct pt_regs *ctx)
 
     // Initialize some of the telemetry event
     ev.id = bpf_get_prandom_u32();
-    ev.done = 0;
     ev.telemetry_type = TE_NETWORK;
     ev.u.network_info.protocol_type = IPPROTO_UDP;
     ev.u.network_info.direction = outbound;
@@ -433,7 +430,6 @@ int kretprobe__ret_tcp_connect(struct pt_regs *ctx)
 
     // Initialize some of the telemetry event
     ev.id = bpf_get_prandom_u32();
-    ev.done = 0;
     ev.telemetry_type = TE_NETWORK;
     ev.u.network_info.mono_ns = bpf_ktime_get_ns();
 

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -612,6 +612,10 @@ static __always_inline int exit_exec(struct pt_regs *__ctx, u32 i_dev, u64 i_ino
 
     bpf_map_delete_elem(&process_ids, &pid_tgid);
 
+    u32 retcode = (u32)PT_REGS_RC(__ctx);
+    if (retcode != 0) {
+        goto Flush;
+    }
 
     ptelemetry_event_t ev = &(telemetry_event_t){
         .id = *id,
@@ -629,7 +633,7 @@ static __always_inline int exit_exec(struct pt_regs *__ctx, u32 i_dev, u64 i_ino
     // re-use the same ev to save stack space
     ev->id = *id;
     ev->telemetry_type = TE_RETCODE;
-    ev->u.r.retcode = (u32)PT_REGS_RC(__ctx);
+    ev->u.r.retcode = retcode;
     push_telemetry_event(__ctx, ev);
 
 Flush:

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -90,7 +90,6 @@ struct bpf_map_def SEC("maps/tail_call_table") tail_call_table = {
 
 #define FILL_TELEMETRY_SYSCALL_EVENT(E, SP)                          \
     u64 pid_tgid = bpf_get_current_pid_tgid();                       \
-    E->done = FALSE;                                                 \
     E->telemetry_type = TE_SYSCALL_INFO;                             \
     E->u.syscall_info.pid = pid_tgid >> 32;                          \
     E->u.syscall_info.tid = pid_tgid & 0xFFFFFFFF;                   \
@@ -191,7 +190,6 @@ static __always_inline void push_telemetry_event(struct pt_regs *ctx, ptelemetry
     {                                                                              \
         ev->u.v.truncated = FALSE;                                                 \
         ev->id = id;                                                               \
-        ev->done = FALSE;                                                          \
         ev->telemetry_type = T;                                                    \
         count = bpf_probe_read_str(&ev->u.v.value, VALUE_SIZE, (void *)PTR + off); \
         if (count == VALUE_SIZE)                                                   \
@@ -233,7 +231,6 @@ static __always_inline void push_telemetry_event(struct pt_regs *ctx, ptelemetry
     if (!br)                                                                     \
     {                                                                            \
         EV->id = id;                                                             \
-        EV->done = FALSE;                                                        \
         EV->telemetry_type = T;                                                  \
         EV->u.v.truncated = FALSE;                                               \
         count = 0;                                                               \
@@ -265,7 +262,6 @@ static __always_inline void push_telemetry_event(struct pt_regs *ctx, ptelemetry
 
 #define SEND_PATH                                                           \
     ev->id = id;                                                            \
-    ev->done = FALSE;                                                       \
     ev->telemetry_type = TE_PWD;                                            \
     if (br == 0)                                                            \
     {                                                                       \
@@ -314,7 +310,6 @@ static __always_inline int enter_exec(syscall_pattern_type_t sp, int fd,
 
     u64 id = bpf_get_prandom_u32();
     ev->id = id;
-    ev->done = FALSE;
     ev->telemetry_type = 0,
     ev->u.v.value[0] = '\0';
     ev->u.v.truncated = FALSE;
@@ -349,7 +344,6 @@ static __always_inline ptelemetry_event_t enter_exec_4_11(syscall_pattern_type_t
 
     id = bpf_get_prandom_u32();
     ev->id = id;
-    ev->done = FALSE;
     ev->telemetry_type = 0,
     ev->u.v.value[0] = '\0';
     ev->u.v.truncated = FALSE;
@@ -618,7 +612,6 @@ static __always_inline int exit_exec(struct pt_regs *__ctx, u32 i_dev, u64 i_ino
 
     ptelemetry_event_t ev = &(telemetry_event_t){
         .id = 0,
-        .done = FALSE,
         .telemetry_type = TE_UNSPEC,
         .u.v = {
             .value[0] = '\0',
@@ -641,7 +634,6 @@ static __always_inline int exit_exec(struct pt_regs *__ctx, u32 i_dev, u64 i_ino
     push_telemetry_event(__ctx, ev);
 
     ev->id = *id;
-    ev->done = TRUE;
     ev->telemetry_type = TE_RETCODE;
     ev->u.r.retcode = (u32)PT_REGS_RC(__ctx);
     push_telemetry_event(__ctx, ev);
@@ -688,7 +680,6 @@ static __always_inline int enter_clone(syscall_pattern_type_t sp, unsigned long 
 
     u64 id = bpf_get_prandom_u32();
     ev->id = id;
-    ev->done = FALSE;
     ev->telemetry_type = 0,
     ev->u.v.value[0] = '\0';
     ev->u.v.truncated = FALSE;
@@ -699,7 +690,6 @@ static __always_inline int enter_clone(syscall_pattern_type_t sp, unsigned long 
     push_telemetry_event(ctx, ev);
 
     ev->id = id;
-    ev->done = FALSE;
     ev->telemetry_type = TE_EXE_PATH;
     ev->u.v.truncated = FALSE;
     long count = 0;
@@ -739,7 +729,6 @@ static __always_inline int exit_clone(struct pt_regs *ctx)
 
     ptelemetry_event_t ev = &(telemetry_event_t){
         .id = 0,
-        .done = TRUE,
         .telemetry_type = 0,
         .u.v = {
             .value[0] = '\0',
@@ -748,7 +737,6 @@ static __always_inline int exit_clone(struct pt_regs *ctx)
     };
 
     ev->id = *id;
-    ev->done = FALSE;
     ev->telemetry_type = TE_CLONE_INFO;
     u32 key = 0;
     pclone_info_t pclone_info = bpf_map_lookup_elem(&clone_info_store, &key);
@@ -773,7 +761,6 @@ static __always_inline int exit_clone(struct pt_regs *ctx)
 
     ev->id = *id;
     bpf_map_delete_elem(&process_ids, &pid_tgid);
-    ev->done = TRUE;
     ev->telemetry_type = TE_RETCODE;
     ev->u.r.retcode = (u32)PT_REGS_RC(ctx);
     push_telemetry_event(ctx, ev);
@@ -822,7 +809,6 @@ static __always_inline int enter_clone3(syscall_pattern_type_t sp, struct clone_
 
     u64 id = bpf_get_prandom_u32();
     ev->id = id;
-    ev->done = FALSE;
     ev->telemetry_type = 0,
     ev->u.v.value[0] = '\0';
     ev->u.v.truncated = FALSE;
@@ -836,7 +822,6 @@ static __always_inline int enter_clone3(syscall_pattern_type_t sp, struct clone_
     bpf_map_update_elem(&process_ids, (u32 *)&pid_tgid, &id, BPF_ANY);
 
     ev->id = id;
-    ev->done = FALSE;
     ev->telemetry_type = TE_EXE_PATH;
     ev->u.v.truncated = FALSE;
     long count = 0;
@@ -882,7 +867,6 @@ static __always_inline int exit_clone3(struct pt_regs *ctx)
 
     ptelemetry_event_t ev = &(telemetry_event_t){
         .id = 0,
-        .done = TRUE,
         .telemetry_type = 0,
         .u.v = {
             .value[0] = '\0',
@@ -891,7 +875,6 @@ static __always_inline int exit_clone3(struct pt_regs *ctx)
     };
 
     ev->id = *id;
-    ev->done = FALSE;
     ev->telemetry_type = TE_CLONE3_INFO;
     u32 key = 0;
     pclone3_info_t pclone3_info = bpf_map_lookup_elem(&clone3_info_store, &key);
@@ -926,7 +909,6 @@ static __always_inline int exit_clone3(struct pt_regs *ctx)
 
     ev->id = *id;
     bpf_map_delete_elem(&process_ids, &pid_tgid);
-    ev->done = TRUE;
     ev->telemetry_type = TE_RETCODE;
     ev->u.r.retcode = (u32)PT_REGS_RC(ctx);
     push_telemetry_event(ctx, ev);
@@ -992,7 +974,6 @@ int kprobe__read_inode_task_struct(struct pt_regs *ctx)
     // prepare event
     ptelemetry_event_t ev = &(telemetry_event_t){
         .id = 0,
-        .done = TRUE,
         .telemetry_type = 0,
         .u.v = {
             .value[0] = '\0',
@@ -1063,7 +1044,6 @@ int kprobe__read_pid_task_struct(struct pt_regs *ctx)
     // send event with ID
     ptelemetry_event_t ev = &(telemetry_event_t){
         .id = 0,
-        .done = TRUE,
         .telemetry_type = 0,
         .u.v = {
             .value[0] = '\0',
@@ -1144,7 +1124,6 @@ static __always_inline int enter_unshare(syscall_pattern_type_t sp, int flags,
 
     u64 id = bpf_get_prandom_u32();
     ev->id = id;
-    ev->done = FALSE;
     ev->telemetry_type = 0,
     ev->u.v.value[0] = '\0';
     ev->u.v.truncated = FALSE;
@@ -1155,7 +1134,6 @@ static __always_inline int enter_unshare(syscall_pattern_type_t sp, int flags,
     push_telemetry_event(ctx, ev);
 
     ev->id = id;
-    ev->done = FALSE;
     ev->telemetry_type = TE_EXE_PATH;
     ev->u.v.truncated = FALSE;
     long count = 0;
@@ -1167,7 +1145,6 @@ static __always_inline int enter_unshare(syscall_pattern_type_t sp, int flags,
     push_telemetry_event(ctx, ev);
 
     ev->id = id;
-    ev->done = FALSE;
     ev->telemetry_type = TE_UNSHARE_FLAGS;
     ev->u.unshare_flags = flags;
     push_telemetry_event(ctx, ev);
@@ -1188,7 +1165,6 @@ static __always_inline int exit_unshare(struct pt_regs *ctx)
 
     ptelemetry_event_t ev = &(telemetry_event_t){
         .id = 0,
-        .done = TRUE,
         .telemetry_type = 0,
         .u.v = {
             .value[0] = '\0',
@@ -1241,7 +1217,6 @@ static __always_inline int enter_exit(syscall_pattern_type_t sp, int status,
 
     u64 id = bpf_get_prandom_u32();
     ev->id = id;
-    ev->done = FALSE;
     ev->telemetry_type = 0,
     ev->u.v.value[0] = '\0';
     ev->u.v.truncated = FALSE;
@@ -1252,7 +1227,6 @@ static __always_inline int enter_exit(syscall_pattern_type_t sp, int status,
     push_telemetry_event(ctx, ev);
 
     ev->id = id;
-    ev->done = FALSE;
     ev->telemetry_type = TE_EXE_PATH;
     ev->u.v.truncated = FALSE;
     long count = 0;
@@ -1264,7 +1238,6 @@ static __always_inline int enter_exit(syscall_pattern_type_t sp, int status,
     push_telemetry_event(ctx, ev);
 
     ev->id = id;
-    ev->done = FALSE;
     ev->telemetry_type = TE_EXIT_STATUS;
     ev->u.exit_status = status;
     push_telemetry_event(ctx, ev);
@@ -1285,7 +1258,6 @@ static __always_inline int exit_exit(struct pt_regs *ctx)
 
     ptelemetry_event_t ev = &(telemetry_event_t){
         .id = 0,
-        .done = TRUE,
         .telemetry_type = 0,
         .u.v = {
             .value[0] = '\0',

--- a/src/script-events.c
+++ b/src/script-events.c
@@ -65,7 +65,6 @@ struct bpf_map_def SEC("maps/process_ids") process_ids = {
 
 #define SEND_PATH                                                           \
     ev->id = id;                                                            \
-    ev->done = FALSE;                                                       \
     ev->telemetry_type = TE_PWD;                                            \
     if (br == 0)                                                            \
     {                                                                       \
@@ -104,7 +103,6 @@ struct bpf_map_def SEC("maps/process_ids") process_ids = {
 
 #define READ_CHAR_STR                                                   \
     ev.id = id;                                                         \
-    ev.done = FALSE;                                                    \
     ev.telemetry_type = TE_CHAR_STR;                                    \
     __builtin_memset(&ev.u.v.value, 0, VALUE_SIZE);                     \
     count = bpf_probe_read_str(&ev.u.v.value, VALUE_SIZE, (void *)str); \
@@ -245,7 +243,6 @@ int kretprobe__ret_script_load(struct pt_regs *ctx)
     // Initialize some of the telemetry event
     id = bpf_get_prandom_u32();
     ev.id = id;
-    ev.done = 0;
     ev.telemetry_type = TE_SCRIPT;
     ev.u.script_info.mono_ns = bpf_ktime_get_ns();
 
@@ -293,7 +290,6 @@ int kretprobe__ret_script_load(struct pt_regs *ctx)
 
     // Output the path. It may only be the first part if the path/name is long
     ev.id = id;
-    ev.done = 0;
     ev.telemetry_type = TE_CHAR_STR;
     push_telemetry_event(ctx, &ev);
 

--- a/src/types.h
+++ b/src/types.h
@@ -319,7 +319,6 @@ typedef struct
 typedef struct
 {
     u64 id;
-    u32 done;
     telemetry_event_type_t telemetry_type;
     union
     {


### PR DESCRIPTION
Do not emit events for exec* syscalls with a non-zero retcode as no process was started. 

I have also removed the unused and unneeded `done` field. 