### PR TITLE
Fix perf buffer and discard bad events

### DIFF
--- a/src/cred-events.c
+++ b/src/cred-events.c
@@ -62,7 +62,7 @@ static __always_inline int dispatch_credentials_event(struct pt_regs *__ctx)
     {
         bpf_perf_event_output(__ctx,
                               &cred_events,
-                              bpf_get_smp_processor_id(),
+                              BPF_F_CURRENT_CPU,
                               pcreds,
                               sizeof(*pcreds));
     }

--- a/src/cred-events.c
+++ b/src/cred-events.c
@@ -18,7 +18,7 @@ struct bpf_map_def SEC("maps/cred_events") cred_events = {
     .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
     .key_size = sizeof(u32),
     .value_size = sizeof(u32),
-    .max_entries = 1024,
+    .max_entries = 0, // let oxidebpf set it to num_cpus
     .pinning = 0,
     .namespace = "",
 };

--- a/src/network-events.c
+++ b/src/network-events.c
@@ -36,7 +36,7 @@ struct bpf_map_def SEC("maps/network_events") network_events = {
     .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
     .key_size = sizeof(u32),
     .value_size = sizeof(u32),
-    .max_entries = MAX_TELEMETRY_STACK_ENTRIES * 64,
+    .max_entries = 0, // let oxidebpf set it to num_cpus
     .pinning = 0,
     .namespace = "",
 };

--- a/src/network-events.c
+++ b/src/network-events.c
@@ -135,7 +135,7 @@ int kretprobe__ret_inet_csk_accept(struct pt_regs *ctx)
     bpf_get_current_comm(ev.u.network_info.process.comm, sizeof(ev.u.network_info.process.comm));
 
     // Output data to generator
-    bpf_perf_event_output(ctx, &network_events, bpf_get_smp_processor_id(), &ev, sizeof(ev));
+    bpf_perf_event_output(ctx, &network_events, BPF_F_CURRENT_CPU, &ev, sizeof(ev));
 
     return 0;
 }
@@ -279,7 +279,7 @@ int kretprobe__ret___skb_recv_udp(struct pt_regs *ctx)
     bpf_get_current_comm(ev.u.network_info.process.comm, sizeof(ev.u.network_info.process.comm));
 
     // Output data to generator
-    bpf_perf_event_output(ctx, &network_events, bpf_get_smp_processor_id(), &ev, sizeof(ev));
+    bpf_perf_event_output(ctx, &network_events, BPF_F_CURRENT_CPU, &ev, sizeof(ev));
     return 0;
 }
 
@@ -404,7 +404,7 @@ int kretprobe__ret_udp_outgoing(struct pt_regs *ctx)
     bpf_get_current_comm(ev.u.network_info.process.comm, sizeof(ev.u.network_info.process.comm));
 
     // Output data to generator
-    bpf_perf_event_output(ctx, &network_events, bpf_get_smp_processor_id(), &ev, sizeof(ev));
+    bpf_perf_event_output(ctx, &network_events, BPF_F_CURRENT_CPU, &ev, sizeof(ev));
     return 0;
 }
 
@@ -481,7 +481,7 @@ int kretprobe__ret_tcp_connect(struct pt_regs *ctx)
     bpf_get_current_comm(ev.u.network_info.process.comm, sizeof(ev.u.network_info.process.comm));
 
     // Output data to generator
-    bpf_perf_event_output(ctx, &network_events, bpf_get_smp_processor_id(), &ev, sizeof(ev));
+    bpf_perf_event_output(ctx, &network_events, BPF_F_CURRENT_CPU, &ev, sizeof(ev));
     return 0;
 }
 

--- a/src/pam-events.c
+++ b/src/pam-events.c
@@ -63,7 +63,7 @@ int uretprobe__pam_start(struct pt_regs *ctx)
 
         bpf_perf_event_output(ctx,
                               &pam_events,
-                              bpf_get_smp_processor_id(),
+                              BPF_F_CURRENT_CPU,
                               ppam,
                               sizeof(*ppam));
     }
@@ -80,7 +80,7 @@ int uprobe__pam_end(struct pt_regs *ctx)
     ev.pam_handle = (u64)PT_REGS_PARM1(ctx);
     bpf_perf_event_output(ctx,
                           &pam_events,
-                          bpf_get_smp_processor_id(),
+                          BPF_F_CURRENT_CPU,
                           &ev,
                           sizeof(ev));
     return 0;
@@ -110,7 +110,7 @@ int uretprobe__pam_authenticate(struct pt_regs *ctx)
     ppam->result = (u32)PT_REGS_RC(ctx);
     bpf_perf_event_output(ctx,
                           &pam_events,
-                          bpf_get_smp_processor_id(),
+                          BPF_F_CURRENT_CPU,
                           ppam,
                           sizeof(*ppam));
 
@@ -143,7 +143,7 @@ int uretprobe__pam_chauthtok(struct pt_regs *ctx)
     ppam->result = (u32)PT_REGS_RC(ctx);
     bpf_perf_event_output(ctx,
                           &pam_events,
-                          bpf_get_smp_processor_id(),
+                          BPF_F_CURRENT_CPU,
                           ppam,
                           sizeof(*ppam));
 
@@ -177,7 +177,7 @@ int uretprobe__pam_set_item(struct pt_regs *ctx)
     ppam->result = (u32)PT_REGS_RC(ctx);
     bpf_perf_event_output(ctx,
                           &pam_events,
-                          bpf_get_smp_processor_id(),
+                          BPF_F_CURRENT_CPU,
                           ppam,
                           sizeof(*ppam));
 
@@ -210,7 +210,7 @@ int uretprobe__pam_setcred(struct pt_regs *ctx)
     ppam->result = (u32)PT_REGS_RC(ctx);
     bpf_perf_event_output(ctx,
                           &pam_events,
-                          bpf_get_smp_processor_id(),
+                          BPF_F_CURRENT_CPU,
                           ppam,
                           sizeof(*ppam));
 

--- a/src/pam-events.c
+++ b/src/pam-events.c
@@ -17,7 +17,7 @@ struct bpf_map_def SEC("maps/pam_events") pam_events = {
     .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
     .key_size = sizeof(u32),
     .value_size = sizeof(u32),
-    .max_entries = 1024,
+    .max_entries = 0, // let oxidebpf set it to num_cpus
     .pinning = 0,
     .namespace = "",
 };

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -399,7 +399,7 @@ Pwd:;
 
     if (to_skip != 0)
     {
-        SKIP_PATH_N(150);
+        SKIP_PATH_N(125);
     }
 
 Send:

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -20,7 +20,7 @@ struct bpf_map_def SEC("maps/mount_events") mount_events = {
     .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
     .key_size = sizeof(u32),
     .value_size = sizeof(u32),
-    .max_entries = 1024,
+    .max_entries = 0, // let oxidebpf set it to num_cpus
     .pinning = 0,
     .namespace = "",
 };
@@ -65,7 +65,7 @@ struct bpf_map_def SEC("maps/process_events") process_events = {
     .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
     .key_size = sizeof(u32),
     .value_size = sizeof(u32),
-    .max_entries = MAX_TELEMETRY_STACK_ENTRIES * 64,
+    .max_entries = 0, // let oxidebpf set it to num_cpus
     .pinning = 0,
     .namespace = "",
 };

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -172,7 +172,7 @@ int kprobe__do_mount(struct pt_regs *ctx)
 
     bpf_perf_event_output(ctx,
                           &mount_events,
-                          bpf_get_smp_processor_id(),
+                          BPF_F_CURRENT_CPU,
                           &ev,
                           sizeof(ev));
 
@@ -181,7 +181,7 @@ int kprobe__do_mount(struct pt_regs *ctx)
 
 static __always_inline void push_telemetry_event(struct pt_regs *ctx, ptelemetry_event_t ev)
 {
-    bpf_perf_event_output(ctx, &process_events, bpf_get_smp_processor_id(), ev, sizeof(*ev));
+    bpf_perf_event_output(ctx, &process_events, BPF_F_CURRENT_CPU, ev, sizeof(*ev));
     __builtin_memset(ev, 0, sizeof(telemetry_event_t));
 }
 

--- a/src/script-events.c
+++ b/src/script-events.c
@@ -20,7 +20,7 @@ struct bpf_map_def SEC("maps/script_events") script_events = {
     .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
     .key_size = sizeof(u32),
     .value_size = sizeof(u32),
-    .max_entries = MAX_TELEMETRY_STACK_ENTRIES * 64,
+    .max_entries = 0, // let oxidebpf set it to num_cpus
     .pinning = 0,
     .namespace = "",
 };

--- a/src/script-events.c
+++ b/src/script-events.c
@@ -126,7 +126,7 @@ struct bpf_map_def SEC("maps/process_ids") process_ids = {
 
 static __always_inline void push_telemetry_event(struct pt_regs *ctx, ptelemetry_event_t ev)
 {
-    bpf_perf_event_output(ctx, &script_events, bpf_get_smp_processor_id(), ev, sizeof(*ev));
+    bpf_perf_event_output(ctx, &script_events, BPF_F_CURRENT_CPU, ev, sizeof(*ev));
     __builtin_memset(ev, 0, sizeof(telemetry_event_t));
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -111,7 +111,8 @@ typedef enum
     TE_EXEC_FILENAME,
     TE_PWD,
     TE_SCRIPT,
-    TE_CHAR_STR
+    TE_CHAR_STR,
+    TE_DISCARD,
 } telemetry_event_type_t;
 
 #define COMMON_FIELDS \

--- a/src/wpm-events.c
+++ b/src/wpm-events.c
@@ -97,7 +97,7 @@ int uprobe__read_return_string(struct pt_regs *ctx)
     bpf_probe_read(ev.value, sizeof(ev.value), (void *)PT_REGS_RC(ctx));
     bpf_perf_event_output(ctx,
                           &rrs_events,
-                          bpf_get_smp_processor_id(),
+                          BPF_F_CURRENT_CPU,
                           &ev,
                           sizeof(ev));
     return 0;
@@ -121,7 +121,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_ptrace_write,
 
         bpf_perf_event_output(ctx,
                               &write_process_memory_events,
-                              bpf_get_smp_processor_id(),
+                              BPF_F_CURRENT_CPU,
                               &ev,
                               sizeof(ev));
     }
@@ -147,7 +147,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_ptrace,
 
         bpf_perf_event_output(ctx,
                               &trace_process_events,
-                              bpf_get_smp_processor_id(),
+                              BPF_F_CURRENT_CPU,
                               &ev,
                               sizeof(ev));
     }
@@ -173,7 +173,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_process_vm_writev_5_5,
 
     bpf_perf_event_output(ctx,
                           &write_process_memory_events,
-                          bpf_get_smp_processor_id(),
+                          BPF_F_CURRENT_CPU,
                           &ev,
                           sizeof(ev));
 
@@ -189,7 +189,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_process_vm_writev,
 
     bpf_perf_event_output(ctx,
                           &write_process_memory_events,
-                          bpf_get_smp_processor_id(),
+                          BPF_F_CURRENT_CPU,
                           &ev,
                           sizeof(ev));
 
@@ -207,7 +207,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_mprotect,
 
     bpf_perf_event_output(ctx,
                           &change_process_memory_events,
-                          bpf_get_smp_processor_id(),
+                          BPF_F_CURRENT_CPU,
                           &ev,
                           sizeof(ev));
 

--- a/src/wpm-events.c
+++ b/src/wpm-events.c
@@ -24,7 +24,7 @@ struct bpf_map_def SEC("maps/wpm_events") write_process_memory_events = {
     .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
     .key_size = sizeof(u32),
     .value_size = sizeof(u32),
-    .max_entries = 1024,
+    .max_entries = 0, // let oxidebpf set it to num_cpus
     .pinning = 0,
     .namespace = "",
 };
@@ -33,7 +33,7 @@ struct bpf_map_def SEC("maps/cpm_events") change_process_memory_events = {
     .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
     .key_size = sizeof(u32),
     .value_size = sizeof(u32),
-    .max_entries = 1024,
+    .max_entries = 0, // let oxidebpf set it to num_cpus
     .pinning = 0,
     .namespace = "",
 };
@@ -42,7 +42,7 @@ struct bpf_map_def SEC("maps/tp_events") trace_process_events = {
     .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
     .key_size = sizeof(u32),
     .value_size = sizeof(u32),
-    .max_entries = 1024,
+    .max_entries = 0, // let oxidebpf set it to num_cpus
     .pinning = 0,
     .namespace = "",
 };
@@ -51,7 +51,7 @@ struct bpf_map_def SEC("maps/rrs_events") rrs_events = {
     .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
     .key_size = sizeof(u32),
     .value_size = sizeof(u32),
-    .max_entries = 1024,
+    .max_entries = 0, // let oxidebpf set it to num_cpus
     .pinning = 0,
     .namespace = "",
 };


### PR DESCRIPTION
This contains a couple of fixes:

* Set `max_entries` to 0 on perfmap so oxidebpf can default them appropiately

* Use `BPF_F_CURRENT_CPU` instead of calling for `bpf_get_smp_processor_id()` as per the docs: https://man7.org/linux/man-pages/man7/bpf-helpers.7.html.

> flags can be set to BPF_F_CURRENT_CPU to indicate that the index of the current CPU core should be used.
  
* Send a discard event forward when we process failed exec starts. This will let the Rust code pop that telemetry id out of its LRU cache. 