### PR TITLE
feat: filter out kernel processes

### DIFF
--- a/src/process-events.c
+++ b/src/process-events.c
@@ -117,14 +117,14 @@ struct bpf_map_def SEC("maps/tail_call_table") tail_call_table = {
      */                                                                                                 \
     void *ts = (void *)bpf_get_current_task();                                                          \
     void *ptr = NULL;                                                                                   \
-    /* check mm field of task_struct                                                                    \
-     * skip kernel processes as they have an mm field of NULL                                           \
-     */                                                                                                 \
     void *mmptr = NULL;                                                                                 \
-    read_value(ts, CRC_TASK_STRUCT_MM, &mmptr, sizeof(mmptr));                                          \
-    if (!mmptr) return 0;                                                                               \
     if (ts)                                                                                             \
     {                                                                                                   \
+        /* check mm field of task_struct                                                                \
+         * skip kernel processes as they have an mm field of NULL                                       \
+         */                                                                                             \
+        read_value(ts, CRC_TASK_STRUCT_MM, &mmptr, sizeof(mmptr));                                      \
+        if (!mmptr) return 0;                                                                           \
         read_value(ts, CRC_TASK_STRUCT_REAL_PARENT, &ptr, sizeof(ptr));                                 \
         read_value(ptr, CRC_TASK_STRUCT_TGID, &ppid, sizeof(ppid));                                     \
         read_value(ts, CRC_TASK_STRUCT_LOGINUID, &luid, sizeof(luid));                                  \

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -117,6 +117,12 @@ struct bpf_map_def SEC("maps/tail_call_table") tail_call_table = {
      */                                                                                                 \
     void *ts = (void *)bpf_get_current_task();                                                          \
     void *ptr = NULL;                                                                                   \
+    /* check mm field of task_struct                                                                    \
+     * skip kernel processes as they have an mm field of NULL                                           \
+     */                                                                                                 \
+    void *mmptr = NULL;                                                                                 \
+    read_value(ts, CRC_TASK_STRUCT_MM, &mmptr, sizeof(mmptr));                                          \
+    if (!mmptr) return 0;                                                                               \
     if (ts)                                                                                             \
     {                                                                                                   \
         read_value(ts, CRC_TASK_STRUCT_REAL_PARENT, &ptr, sizeof(ptr));                                 \
@@ -146,13 +152,6 @@ int kprobe__do_mount(struct pt_regs *ctx)
 
 static __always_inline void push_telemetry_event(struct pt_regs *ctx, ptelemetry_event_t ev)
 {
-    // check mm field of task_struct
-    // skip pushing kernel process events as they have an mm field of NULL
-    void *ts = (void *)bpf_get_current_task();
-    void *ptr = NULL;
-    read_value(ts, CRC_TASK_STRUCT_MM, &ptr, sizeof(ptr));
-    if (!ptr) return;
-
     bpf_perf_event_output(ctx, &process_events, BPF_F_CURRENT_CPU, ev, sizeof(*ev));
     __builtin_memset(ev, 0, sizeof(telemetry_event_t));
 }


### PR DESCRIPTION
[Jira Story - CWP-444](https://redcanary.atlassian.net/browse/CWP-444?atlOrigin=eyJpIjoiMjZlMjIzMWNhZTA1NDM0M2EyMzFmYjZkYjMxMDI0OGYiLCJwIjoiaiJ9)

At the moment the eBPF sensor collects telemetry on process exits from Kernel processes. This PR would filter this type of telemetry out to reduce the noise in the output. 

I tested this by greping for process exits with a `uid` of `0` and `login_uid` of `None` when running `proc_events` while also running the audit sensor. Stopping execution of `cfsvcd` would cause a lot of these process exit events to show in the eBPF telemetry. 

Before applying filter:
![Screen Shot 2022-02-18 at 5 39 48 PM](https://user-images.githubusercontent.com/93352097/154780111-2e4793cd-379c-42cb-a3b5-987eef4e1c38.png)

After applying filter:
![Screen Shot 2022-02-18 at 5 45 55 PM](https://user-images.githubusercontent.com/93352097/154780114-7dd4d2b4-e267-453e-8c44-0e3807339f31.png)
