### PR TITLE
Use #pragma unroll rather than macros for loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # redcanary-ebpf-sensor
 
 This project consists of a variety of eBPF applications aimed at gathering events
-of interest for [Red Canary's Cloud Workload Protection](https://redcanary.com/products/cloud-workload-protection/) 
+of interest for [Red Canary's Cloud Workload Protection](https://redcanary.com/products/cloud-workload-protection/)
 product.
 
-These applications do not use [BCC](https://github.com/iovisor/bcc) to build. The 
+These applications do not use [BCC](https://github.com/iovisor/bcc) to build. The
 main objective of this design is to have a compile once, run everywhere application.
 
 To build this project run
@@ -12,3 +12,21 @@ To build this project run
 
 A vscode cpp properties files has been included. Make sure to update the include path with the path
 on your local system where the kernel header files are located
+
+## Validate Instruction Count
+
+Due to older kernel limitations (< 5.2) the instruction limit for our
+ebpf programs is 4096. This was changed in Kernel 5.2+ to be 1 million
+but we cannot rely on that at this time. To verify that we aren't
+going over the limit, after modifying an ebpf program run it through
+`llvm-objdump` and check its instruction count:
+
+```bash
+llvm-objdump -d <PATH_TO_COMPILED_FILE> -j <SPECIFIC_SECTION_TO_ANALYZE> | less
+```
+
+You may ommit the `-j <SPECIFIC_SECTION_TO_ANALYZE>` if you want to
+check all the sections at the same time.
+
+eBPF programs can branch (but not jump back!) so make sure to check
+that none of the branches go over the 4096 instructions limit.


### PR DESCRIPTION
I started looking at this code again to address a race condition (not fixed in this PR) and got annoyed by how hard some of it is to read. In service of making changes easier I have replaced the `#REPEAT` macro in `process_events.c` with the `clang` `#pragma unroll` directive. This directive does the loop unrolling for us so we don't need fancy macros to simulate for-loops anymore. This still has the limitation that they have to be bounded but that's good enough for us. 

I also went ahead and added a version of push event that does not clear the event. This was pretty expensive (# of instructions) in our loops especially since in those loops we want to keep the same `id` and `telemetry_type`, and just change the data. I still kept the old one and only changed it for the loop code to avoid any risk on some areas where we are depending on that variable being cleared. 

All in all these had a good effect in our number of instructions. 

Before the change:
`sys_execveat_411`: 3565
`sys_execve`: 3836
`sys_execve_tc_argv` AND `sys_execveat_tc_argv`  : 1701

After the change:
`sys_execveat_411`: 2863
`sys_execve`: 2987
`sys_execve_tc_argv` AND `sys_execveat_tc_argv`  : 878

This should give us room to add more code to these programs which we'll need to do in an upcoming PR to fix the aforementioned race condition. 

I have tested that the consistency check still passes and that it still works with a high number of long-named arguments and a deeply nested long-named folder. 