### PR TITLE
Send done signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,17 @@ check all the sections at the same time.
 
 eBPF programs can branch (but not jump back!) so make sure to check
 that none of the branches go over the 4096 instructions limit.
+
+## License
+
+Our eBPF programs have a section:
+
+```c
+char _license[] SEC("license") = "GPL";
+```
+
+We have, however, cleared with legal that this does not mean that its
+viral nature would propagate to users of these programs as they are
+packaged separately and live separately. This is noted here just as
+documentation to any future reader that while GPL looks scary in this
+case it is *okay*.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,55 @@ To build this project run
 A vscode cpp properties files has been included. Make sure to update the include path with the path
 on your local system where the kernel header files are located
 
+## Gotchas and Patterns
+
+### Dummy Telemetry Event
+
+At the beginning of the programs we often have code that looks like:
+
+```c
+telemetry_event_t sev = {0};
+```
+
+We then proceed to send `&sev` to our functions and set the proper values there. This is done for two reasons:
+
+1. We want to save stack space, so by creating a single dummy event at
+   the top we can remind ourselves that this is the only event we ever
+   want to have at a time and it is meant to be reused.
+
+2. The eBPF verifier does not like uninitialized padding. When
+   initializing a padded struct in C, not all of the space occupied by
+   the struct necessarily gets initialized as padding may exist
+   between fields, or empty space unused by some union members. The
+   eBPF verifier does not like this so to guarantee nothing is
+   unitialized we need to zero out all of the space for the event
+   struct. For more information see [this
+   issue](https://github.com/iovisor/bcc/issues/2623).
+
+### Per CPU structures
+
+Be careful when using PERCPU structures (such as
+`BPF_MAP_TYPE_PERFCPU_ARRAY`). While an eBPF program is not
+preemptable, syscalls are. This means that a kprobe for a syscall may
+happen in one CPU but its kretprobe will happen in a different
+CPU. This means that passing data using per cpu structures accross
+programs will not always work in multicore systems. Note, however,
+that tail calling is *NOT* preemptable, so it is okay to pass
+information using per cpu structures through tail calls.
+
+### Kprobe and Kretprobe synchronization
+
+Since syscalls may start and finish in different CPUs (they are
+preemptable), we need to be send extra data to synchronize them in
+user space. To do this, we send a a `TE_ENTER_DONE` event as the very
+last event produced by a kprobe. Note that since programs may tail
+call into other programs we need to follow that tail call through and
+send it as the very last event in the final tail call. We also rely on
+the `TE_RETCODE` event being the last event in a `kretprobe` so no
+extra signaling event is done for them. If this changes in the future
+(e.g., due to tail calling) we'll need to add synchronization events
+there too.
+
 ## Validate Instruction Count
 
 Due to older kernel limitations (< 5.2) the instruction limit for our

--- a/src/types.h
+++ b/src/types.h
@@ -289,30 +289,11 @@ typedef struct
 typedef struct
 {
     u64 flags;
-    u64 stack;
-    u32 parent_tid;
-    u32 child_tid;
-    u64 tls;
-    u64 p_ptr;
-    u64 c_ptr;
 } clone_info_t, *pclone_info_t;
 
 typedef struct
 {
     u64 flags;
-    u64 pidfd;
-    u64 child_tid;
-    u64 parent_tid;
-    u64 exit_signal;
-    u64 stack;
-    u64 stack_size;
-    u64 tls;
-    u64 set_tid;
-    u64 set_tid_size;
-    u64 cgroup;
-    u64 c_ptr;
-    u64 p_ptr;
-    u64 size;
 } clone3_info_t, *pclone3_info_t;
 
 typedef struct

--- a/src/types.h
+++ b/src/types.h
@@ -111,6 +111,7 @@ typedef enum
     TE_SCRIPT,
     TE_CHAR_STR,
     TE_DISCARD,
+    TE_ENTER_DONE,
 } telemetry_event_type_t;
 
 #define COMMON_FIELDS \
@@ -239,7 +240,6 @@ typedef struct
     u32 luid;
     u32 euid;
     u32 egid;
-    char comm[16];
 } syscall_info_t, *psyscall_info_t;
 
 enum direction_t


### PR DESCRIPTION
https://redcanary.atlassian.net/browse/CWP-595

This adds a new event `TE_ENTER_DONE` that tells the user space when the enter point for a syscall (usually the kprobe) is done sending events. This will let us synchronize with `TE_RETCODE` so we know when both the enter and exit events are done and we can now construct the event fully. I didn't know what to call this new event, I am also partial to `TE_KPROBE_DONE` but I didn't use it because in the exit syscall program there is no kprobe vs kretprobe, they are all done in the same kprobe and I didn't know if that name would then cause confusion. 

I also added quite a bit of tribal knowledge that I had in the README so it is not just stored in my or (former) R&D devs' brains 😁 

Its sibling PR is: https://github.com/redcanaryco/cwp-plugins/pull/117 which can can be pulled to help test the changes in the ebpf programs. 