### PR TITLE
Handle exec and fork in threads

### DIFF
--- a/src/process-events.c
+++ b/src/process-events.c
@@ -195,10 +195,12 @@ static __always_inline int start_syscall(struct pt_regs *ctx, ptelemetry_event_t
     return 0;
 }
 
-// If the retcode < 0, returns true and sends a discard event. Else,
-// returns false.
+// Sends a discard event and returns true if the retcode in the ctx is
+// an error code.
 static __always_inline bool check_discard(struct pt_regs *ctx, ptelemetry_event_t ev)
 {
+    // check for < 0 rather than just non-zero because forks return a
+    // positive value on successes (the pid of the new process)
     int retcode = (int)PT_REGS_RC(ctx);
     if (retcode < 0) {
         ev->telemetry_type = TE_DISCARD;


### PR DESCRIPTION
Includes 4 fixes to the process programs:

* We were reporting on clones caused by thread's spawning. The goal of the programs was to report on new PIDs being created, new TIDs aren't useful to us so we will now intentionally not send clone events with the `CLONE_THREAD` flag.

* Execs within threads were not being reported properly due to the tid and pid being different between the kprobe and the kretprobe. This fixes it by only using the pid for exec* syscalls. 

* We were pointlessly reporting on failed unshare calls.

* We were pointlessly reporting on failed clone-like calls. 

These are each split into their own commit so it. may be easier to review that way. 