### PR TITLE
Separate telemetry types

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -97,18 +97,14 @@ typedef enum
     TE_UNSPEC,
     TE_SYSCALL_INFO,
     TE_COMMAND_LINE,
-    TE_CURRENT_WORKING_DIRECTORY,
     TE_FILE_INFO,
     TE_RETCODE,
     TE_CLONE_INFO,
     TE_CLONE3_INFO,
     TE_UNSHARE_FLAGS,
-    TE_EXIT_STATUS,
     TE_EXEC_FILENAME,
     TE_EXEC_FILENAME_REV,
     TE_PWD,
-    TE_SCRIPT,
-    TE_CHAR_STR,
     TE_DISCARD,
     TE_ENTER_DONE,
 } telemetry_event_type_t;
@@ -229,12 +225,6 @@ typedef struct
 
 typedef struct
 {
-    u32 new_pid;
-    u64 fork_flags;
-} process_fork_info_t;
-
-typedef struct
-{
     COMMON_FIELDS;
     u32 luid;
     u32 euid;
@@ -305,9 +295,7 @@ typedef struct
         file_info_t file_info;
         clone_info_t clone_info;
         clone3_info_t clone3_info;
-        script_info_t script_info;
         int unshare_flags;
-        int exit_status;
         struct
         {
             char value[VALUE_SIZE];
@@ -347,3 +335,21 @@ typedef enum
     SYS_EXECVEAT_TC_ARGV,
     HANDLE_PWD,
 } tail_call_slot_t;
+
+typedef enum {
+    SM_PWD,
+    SM_SCRIPT,
+    SM_CHAR_STR,
+} script_message_type_t;
+
+typedef struct {
+    u32 event_id;
+    script_message_type_t type;
+    union {
+        script_info_t script_info;
+        struct {
+            char value[VALUE_SIZE];
+            char truncated;
+        } v;
+    } u;
+} script_message_t, *pscript_message_t;

--- a/src/types.h
+++ b/src/types.h
@@ -5,8 +5,6 @@
 #include <linux/types.h>
 #include <linux/limits.h>
 
-#define MAX_TELEMETRY_STACK_ENTRIES 1024
-
 #define MAX_ADDRESSES 16
 #define TRUE 1
 #define FALSE 0
@@ -94,20 +92,20 @@ typedef enum
 
 typedef enum
 {
-    TE_UNSPEC,
-    TE_SYSCALL_INFO,
-    TE_COMMAND_LINE,
-    TE_FILE_INFO,
-    TE_RETCODE,
-    TE_CLONE_INFO,
-    TE_CLONE3_INFO,
-    TE_UNSHARE_FLAGS,
-    TE_EXEC_FILENAME,
-    TE_EXEC_FILENAME_REV,
-    TE_PWD,
-    TE_DISCARD,
-    TE_ENTER_DONE,
-} telemetry_event_type_t;
+    PM_UNSPEC,
+    PM_SYSCALL_INFO,
+    PM_COMMAND_LINE,
+    PM_FILE_INFO,
+    PM_RETCODE,
+    PM_CLONE_INFO,
+    PM_CLONE3_INFO,
+    PM_UNSHARE_FLAGS,
+    PM_EXEC_FILENAME,
+    PM_EXEC_FILENAME_REV,
+    PM_PWD,
+    PM_DISCARD,
+    PM_ENTER_DONE,
+} process_message_type_t;
 
 #define COMMON_FIELDS \
     u32 pid;          \
@@ -292,8 +290,8 @@ typedef struct {
 
 typedef struct
 {
-    u64 id;
-    telemetry_event_type_t telemetry_type;
+    u64 event_id;
+    process_message_type_t type;
     union
     {
         syscall_info_t syscall_info;
@@ -308,7 +306,7 @@ typedef struct
             u64 retcode;
         } r;
     } u;
-} telemetry_event_t, *ptelemetry_event_t;
+} process_message_t, *pprocess_message_t;
 
 // clone3 args are not available in sched.h until 5.3, and we build against 4.4
 struct clone_args

--- a/src/types.h
+++ b/src/types.h
@@ -285,6 +285,11 @@ typedef struct
     u64 flags;
 } clone3_info_t, *pclone3_info_t;
 
+typedef struct {
+    char value[VALUE_SIZE];
+    char truncated;
+} telemetry_value_t;
+
 typedef struct
 {
     u64 id;
@@ -296,11 +301,7 @@ typedef struct
         clone_info_t clone_info;
         clone3_info_t clone3_info;
         int unshare_flags;
-        struct
-        {
-            char value[VALUE_SIZE];
-            char truncated;
-        } v;
+        telemetry_value_t v;
         union
         {
             u64 pid_tgid;
@@ -347,9 +348,6 @@ typedef struct {
     script_message_type_t type;
     union {
         script_info_t script_info;
-        struct {
-            char value[VALUE_SIZE];
-            char truncated;
-        } v;
+        telemetry_value_t v;
     } u;
 } script_message_t, *pscript_message_t;

--- a/src/types.h
+++ b/src/types.h
@@ -100,7 +100,6 @@ typedef enum
     TE_CURRENT_WORKING_DIRECTORY,
     TE_FILE_INFO,
     TE_RETCODE,
-    TE_NETWORK,
     TE_CLONE_INFO,
     TE_CLONE3_INFO,
     TE_UNSHARE_FLAGS,
@@ -284,7 +283,7 @@ typedef struct
             struct in6_addr src_addr;
         } ipv6;
     } protos;
-} network_info_t, *pnetwork_info_t;
+} network_event_t, *pnetwork_event_t;
 
 typedef struct
 {
@@ -306,7 +305,6 @@ typedef struct
         file_info_t file_info;
         clone_info_t clone_info;
         clone3_info_t clone3_info;
-        network_info_t network_info;
         script_info_t script_info;
         int unshare_flags;
         int exit_status;


### PR DESCRIPTION
This is a pure refactor, there are no changes to behavior. 

We've been using an union to represent process, network, and script "events", even though the programs always sends them in different perfmaps so there is no need for them to use the same type. This makes it a little harder to use when consuming the types as there are more variants that we have to handle that are not actually needed. This PR separates them into their own type. It also renames the script and process "events", as "messages" instead with an event_id. This is because multiple messages (what we send in the buffer) relate to the same event (the syscall that triggered it) so we should be using different names for these two concepts. 