### PR TITLE
append the thread id to the random number to make it more unique

### DIFF
--- a/src/process-events.c
+++ b/src/process-events.c
@@ -435,7 +435,7 @@ static __always_inline int enter_exec_4_11(struct pt_regs *ctx, pprocess_message
     u32 pid = pid_tgid >> 32;
     u32 tid = pid_tgid & 0xFFFFFFFF;
     // deliberately not using BPF_ANY because we do not want to
-    // override it if another thread has already called for exec
+    // overwrite it if another thread has already called for exec
     if (bpf_map_update_elem(&exec_tids, &pid, &tid, BPF_NOEXIST) < 0) {
         bpf_map_delete_elem(&process_ids, &pid_tgid);
         return -1;
@@ -901,7 +901,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_exit, int status)
 {
     u64 pid_tgid = bpf_get_current_pid_tgid();
 
-    // exit of a non-main thead
+    // exit of a non-main thread
     if ((pid_tgid >> 32) ^ (pid_tgid & 0xFFFFFFFF)) return 0;
 
     process_message_t sev = {0};


### PR DESCRIPTION
A few fixes here:

* Append the `tid` to the event_id. We were seeing a small amount of collisions when assuming the event_id would be unique for the duration of an event. We are hoping that adding the thread id makes that a little more guaranteed. If we still see collisions we may just need to ditch the event_id as an unique id and find a new way of collecting different messages under the same event

* In `read_pid_task_struct`, use the current pid_tgid as the key for `process_ids` rather than the parent of the passed in `task_struct`. In theory if a clone is done with the `CLONE_PARENT` flag, the parent and the process doing the fork are different so we should be using the pid/tidof the process doing the fork as that is the pid/tid that was saved in the kprobe. 

* Added an `exec_tids` map to track what tid started the execution. This is done because when a thread starts an `exec`, the parent could have been in the middle of doing a syscall. In the previous version, the thread would put the parent tid/pid as the key which would conflict with any event currently being done by the parent. Now the key will stay as the current thread's tid/pid so they are different between threads. In execs we will check if there are any threads running an exec for the process and get the thread id out this new `exec_tids` map and use it properly get the event id out of the `process_ids` map. 

* Previously we were using `do_exit` as the probe for exit syscalls. This has some downsides:
   1. We couldn't differentiate between exit vs exit group
   2. `do_exit` gets called by more than just the exit syscalls. We only care about syscalls so we were getting more exit events than needed.
   3. A non-main thread is allowed to do an `exit_group` to exit the entire thread group, but because we were checking if tid == pid, we were missing some exit events. 