### PR TITLE
Collapse process messages

### DIFF
--- a/src/process-events.c
+++ b/src/process-events.c
@@ -608,22 +608,7 @@ static __always_inline int exit_exec(struct pt_regs *ctx, process_message_t *pm,
     pm->type = pm_type;
     pm->u.syscall_info.data.exec_info.event_id = event->exec_id;;
     pm->u.syscall_info.retcode = retcode;
-
-    u32 i_dev = 0;
-    u64 i_ino = 0;
-    void *sptr = NULL;
-    void *ptr = NULL;
-
-    read_value(exe, CRC_FILE_F_INODE, &ptr, sizeof(ptr));
-    read_value(ptr, CRC_INODE_I_SB, &sptr, sizeof(sptr));
-    read_value(sptr, CRC_SBLOCK_S_DEV, &i_dev, sizeof(i_dev));
-    read_value(ptr, CRC_INODE_I_INO, &i_ino, sizeof(i_ino));
-
-    pm->u.syscall_info.data.exec_info.file_info.inode = i_ino;
-    pm->u.syscall_info.data.exec_info.file_info.devmajor = MAJOR(i_dev);
-    pm->u.syscall_info.data.exec_info.file_info.devminor = MINOR(i_dev);
-    bpf_get_current_comm(&pm->u.syscall_info.data.exec_info.file_info.comm,
-                         sizeof(pm->u.syscall_info.data.exec_info.file_info.comm));
+    pm->u.syscall_info.data.exec_info.file_info = extract_file_info(exe);
 
     return 0;
 

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -369,7 +369,7 @@ static __always_inline int write_argv(struct pt_regs *ctx, const char __user *co
         // we are ignoring the case of the string having been too
         // large. If this becomes a problem in practice we can tweak
         // the values somewhat.
-        int sz = write_string(ptr, buffer, buffer_offset, 256);
+        int sz = write_string(ptr, buffer, buffer_offset, 1024);
         if (sz < 0) {
             ret = sz;
             goto Done;

--- a/src/types.h
+++ b/src/types.h
@@ -79,7 +79,6 @@ typedef enum
     SP_SETREGID,
     SP_SETRESUID,
     SP_SETRESGID,
-    SP_UNSHARE,
     SP_CLONE,
     SP_CLONE3,
     SP_FORK,
@@ -97,7 +96,6 @@ typedef enum
     PM_RETCODE,
     PM_CLONE_INFO,
     PM_CLONE3_INFO,
-    PM_UNSHARE_FLAGS,
     PM_EXEC_FILENAME,
     PM_EXEC_FILENAME_REV,
     PM_PWD,
@@ -105,6 +103,7 @@ typedef enum
     PM_ENTER_DONE,
     PM_EXIT,
     PM_EXITGROUP,
+    PM_UNSHARE,
 } process_message_type_t;
 
 #define COMMON_FIELDS \
@@ -221,12 +220,17 @@ typedef struct
     char comm[TASK_COMM_LEN];
 } file_info_t, *pfile_info_t;
 
+typedef union {
+    u32 unshare_flags;
+} process_data_union_t;
+
 typedef struct
 {
     COMMON_FIELDS;
     u32 luid;
     u32 euid;
     u32 egid;
+    process_data_union_t data;
 } syscall_info_t, *psyscall_info_t;
 
 enum direction_t
@@ -300,7 +304,6 @@ typedef struct
         file_info_t file_info;
         clone_info_t clone_info;
         clone3_info_t clone3_info;
-        int unshare_flags;
         telemetry_value_t v;
         union
         {

--- a/src/types.h
+++ b/src/types.h
@@ -82,6 +82,16 @@ typedef enum
     SP_EXECVEAT,
 } syscall_pattern_type_t;
 
+typedef enum {
+    PMW_BUFFER_FULL = 1,
+    PMW_TAIL_CALL_MAX,
+    PMW_MAX_PATH,
+    PMW_DOUBLE_EXEC,
+    PMW_FILLED_EVENTS,
+    PMW_WRONG_TYPE,
+    PMW_UNEXPECTED,
+} process_message_warning_t;
+
 typedef enum
 {
     PM_UNSPEC,
@@ -96,6 +106,7 @@ typedef enum
     PM_EXECVEAT,
     PM_STRINGS,
     PM_DISCARD,
+    PM_WARNING,
 } process_message_type_t;
 
 #define COMMON_FIELDS \

--- a/src/types.h
+++ b/src/types.h
@@ -79,8 +79,6 @@ typedef enum
     SP_SETREGID,
     SP_SETRESUID,
     SP_SETRESGID,
-    SP_EXIT,
-    SP_EXITGROUP,
     SP_UNSHARE,
     SP_CLONE,
     SP_CLONE3,
@@ -105,6 +103,8 @@ typedef enum
     PM_PWD,
     PM_DISCARD,
     PM_ENTER_DONE,
+    PM_EXIT,
+    PM_EXITGROUP,
 } process_message_type_t;
 
 #define COMMON_FIELDS \

--- a/src/types.h
+++ b/src/types.h
@@ -79,10 +79,6 @@ typedef enum
     SP_SETREGID,
     SP_SETRESUID,
     SP_SETRESGID,
-    SP_CLONE,
-    SP_CLONE3,
-    SP_FORK,
-    SP_VFORK,
     SP_EXECVE,
     SP_EXECVEAT,
 } syscall_pattern_type_t;
@@ -94,8 +90,6 @@ typedef enum
     PM_COMMAND_LINE,
     PM_FILE_INFO,
     PM_RETCODE,
-    PM_CLONE_INFO,
-    PM_CLONE3_INFO,
     PM_EXEC_FILENAME,
     PM_EXEC_FILENAME_REV,
     PM_PWD,
@@ -104,6 +98,10 @@ typedef enum
     PM_EXIT,
     PM_EXITGROUP,
     PM_UNSHARE,
+    PM_CLONE,
+    PM_CLONE3,
+    PM_FORK,
+    PM_VFORK,
 } process_message_type_t;
 
 #define COMMON_FIELDS \
@@ -220,8 +218,14 @@ typedef struct
     char comm[TASK_COMM_LEN];
 } file_info_t, *pfile_info_t;
 
+typedef struct {
+    u32 child_pid;
+    u64 flags;
+} clone_info_t;
+
 typedef union {
     u32 unshare_flags;
+    clone_info_t clone_info;
 } process_data_union_t;
 
 typedef struct
@@ -231,6 +235,7 @@ typedef struct
     u32 euid;
     u32 egid;
     process_data_union_t data;
+    int retcode;
 } syscall_info_t, *psyscall_info_t;
 
 enum direction_t
@@ -279,16 +284,6 @@ typedef struct
     ip_addr_t protos;
 } network_event_t, *pnetwork_event_t;
 
-typedef struct
-{
-    u64 flags;
-} clone_info_t, *pclone_info_t;
-
-typedef struct
-{
-    u64 flags;
-} clone3_info_t, *pclone3_info_t;
-
 typedef struct {
     char value[VALUE_SIZE];
     char truncated;
@@ -302,8 +297,6 @@ typedef struct
     {
         syscall_info_t syscall_info;
         file_info_t file_info;
-        clone_info_t clone_info;
-        clone3_info_t clone3_info;
         telemetry_value_t v;
         union
         {

--- a/src/types.h
+++ b/src/types.h
@@ -311,6 +311,10 @@ typedef struct
         struct {
             u64 event_id;
         } discard_info;
+        struct {
+            process_message_warning_t code;
+            process_message_type_t message_type;
+        } warning_info;
     } u;
     // not allowed inside union
     char strings[];


### PR DESCRIPTION
# Summary

All but exec* syscall events will now only trigger a single message in the perfmap. Exec* syscalls will trigger two (and exactly two!) syscalls. I left some TODOs in there on purpose for places that we may consider doing more things either in this PR or after (e.g., sending error events from the programs to user space so we can monitor it better?). 

# Why

There have been a few bugs in the ebpf programs due to synchronization of the messages (see introduction of `TE_ENTER_DONE`). For some reason though, we keep seeing these errors in the wild even though we have had trouble replicating them locally. Additionally, whenever some messages in the middle get dropped it is hard to for the consumer of the messages to know if the event still has enough data to be valid or not. (e.g., it could drop part of the exe path, or the args, or just the return code). Also, because we sent a message per argument, or per path segment, we were often sending a LOT of messages for just a single event which was not efficient. This PR collapses them all into one (and two for exec*) messages per syscall event. This makes it much easier to handle in userspace since it no longer needs to wait for "all the right messages", it will already have all the necessary data in the one (or two) messages. 

# How

For non exec* events, this was pretty easy: We make a map of "incomplete data" that gets created in the kprobe, then the kretprobe reads this map (pid + tid as the key), and sends the full event in the kretprobe. This also lets us check for the return code before we send any messages through the perfmap thus saving space on failed syscalls. 

For exec* events, this is a little hairier for a couple of reasons:
  * The arguments that are passed as pointers (argv, filename) can only be read in the kprobe as the executable image changes by the time the kretprobe is called making thus pointers "invalid" by that time (the pointers belong in the virtual memory of the old image). This means that we cannot simply save the pointers, but rather we have to copy these strings into something. 
  * The data size is flexible as we want to know things like exe path, cwd, and arguments. This means that we need more memory than the stack of eBPF allows us to have (512 bytes). 
 
To address these two issues with exec* syscalls, a per-cpu buffer was added with 32KB of memory allocated per buffer. This buffer is used to save data that can't fit in the stack, namely the strings. This buffer is also aware of how much of its data is actually used so we don't have to send the entire 32KB to user space, but instead only the amount that was filled by the program. Since a kprobe and a kretprobe don't have to be executed in the same CPU, this buffer cannot be used to send information from the kprobe to the kretprobe. The kprobe sends a message with just string data and an event id (similar to the old architecture), and then the kretprobe sends another message with the same event id and the rest of the data (i.e., retcode). In user space, it is sufficient to wait for both messages to come in, and there is no need to synchronize which one needs to come first or last, it just always needs both. 

# Assumptions

* A path sent to execve will always be at most `PATH_MAX` (4096 w/ null byte). If this assumption is not met then the path will be truncated. While an absolute path can go over `PATH_MAX`, everything I saw online seemed to indicate that paths sent to syscalls will respect `PATH_MAX`. 

* A path segment will be at most `NAME_MAX` (256 w/ null byte). If this assumption is not met then segments of a current working directory or the executable for execveat will be truncated. I think this is a good enough assumption and simplifies code both in the programs and in readers of the messages so it doesn't have to handle truncations. If this proves problematic we can bump it. 

* Each argument will be at most 256 bytes. Each argument will be truncated after that. I think this is preferred to having a single argument eat up all of the available buffer. At least this way it gives individual arguments enough space so we know what it was trying to do. If this proves problematic we can bump it. 

* Same as the old programs, we are restricted on number of tail calls and instructions. Arguments are limited to 1200 (75 per tail call and 16 tail calls). Path segments are limited to 204 (12 per tail call, and 17 tail calls). The code purposefully does not let the path segments from from tail calling further to give room for the arguments. The number of instructions per tail call is limited by the 4096 instruction limit in older kernels. We can potentially bump this further for newer kernels if we made separate programs, that's left as a todo for another time if necessary. 

* Same as the old programs, we are assuming that there is no more than 1024 syscalls being executed at one time (the size of the `incomplete_events` map). This number can be very easily bumped though. Hashes aren't pre-allocated (unlike arrays) so I don't think there is much cost to making this number higher, so I may bump it to something like 8K to be "extra safe" but I am not yet sure. 