### PR TITLE
fix bug around bpf_map_delete_elem

### DIFF
--- a/src/network-events.c
+++ b/src/network-events.c
@@ -342,13 +342,12 @@ int kretprobe__ret_udp_outgoing(struct pt_regs *ctx)
 
     // Lookup the corresponding sk_buff* that we saved when udp_outgoing
     skpp = bpf_map_lookup_elem(&udp_outgoing_map, &index);
-    if (skpp == NULL)
-    {
-        return 0;
-    }
+    if (skpp == NULL) return 0;
+    unsigned char *skbuff_base = (unsigned char *)*skpp;
+
+    // only delete after we have gotten the value behind skpp
     bpf_map_delete_elem(&udp_outgoing_map, &index);
 
-    unsigned char *skbuff_base = (unsigned char *)*skpp;
     if (skbuff_base == NULL)
     {
         return 0;
@@ -463,15 +462,16 @@ int kretprobe__ret_tcp_connect(struct pt_regs *ctx)
     // if ipv4 do one thing else do the other
 
     skpp = bpf_map_lookup_elem(&tcp_connect, &index);
-    if (skpp == 0)
-    {
-        return 0;
-    }
-    bpf_map_delete_elem(&tcp_connect, &index);
+    if (skpp == 0) return 0;
+
 
     // Deref
     _sock skp = *skpp;
     unsigned char *skp_base = (unsigned char *)skp;
+
+    // only delete after we have gotten the value behind skpp
+    bpf_map_delete_elem(&tcp_connect, &index);
+
     if (skp_base == NULL)
     {
         return 0;


### PR DESCRIPTION
Alright, I think I finally found the real source of the weird bugs I had been noticing. 

We were deleting elements from the bpf maps but then still using the pointer to the now deleted element. This surprisingly works most of the time, but every so often the pointer is now either pointing to nothing (but not to garbage so no memory corruption thankfully!), or to a different value in the map which leads to us sending events with incorrect data.  

The reason we wanted to delete right away was to make sure we didn't forget to delete it during an early exit. I have moved the deletes into a common goto tag that is now used instead of explicit returns during early exits. I have tested and verified that I can put my machine under a lot of stress and I no longer see any errors. 