### PR TITLE
fix up some error handling

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -90,6 +90,7 @@ typedef enum {
     PMW_FILLED_EVENTS,
     PMW_WRONG_TYPE,
     PMW_UNEXPECTED,
+    PMW_MISSING_EVENT,
 } process_message_warning_t;
 
 typedef enum


### PR DESCRIPTION
* exec* kprobes were not propagating user warnings
* `read_pid_task_struct` was emitting errors that didn't need to be emitted by it. Also it was assuming it came from a clone syscall. If the errors are real is better to let the `kretprobe` handle it so we have better information. Also `read_pid_task_struct` can be hooked into functions that are called by more than just clone-like syscalls so it's better to just do nothing if we aren't in a syscall we expect to be in. 
* We were not discarding during an early exit for `enter_exec`. In reality this may not get hit but it's better to be safe here. 
* Add a user warning if for some reason we cannot extract the executable in an execve kretprobe. 
* Add a user warning if there is an an `exec_tid` but no `incomplete_event` for that exec* syscall. This would point to an internal bug. 