### PR TITLE
add more information when sending warnings to userspace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ depends:
 	apt-get update
 	apt-get install -y llvm-$(CLANG_VER) clang-$(CLANG_VER) libclang-$(CLANG_VER)-dev \
 		linux-headers-$(KERNEL_HEADER_VERSION) \
-		make binutils curl coreutils gcc
+		make binutils curl coreutils gcc libc6-dev-i386
 
 no_wrapper:
 	$(MAKE) $(OBJS)

--- a/src/types.h
+++ b/src/types.h
@@ -300,6 +300,11 @@ typedef struct {
     char truncated;
 } telemetry_value_t;
 
+typedef union {
+    int err;
+    process_message_type_t actual_type;
+} error_info_t;
+
 typedef struct
 {
     process_message_type_t type;
@@ -315,6 +320,7 @@ typedef struct
         struct {
             process_message_warning_t code;
             process_message_type_t message_type;
+            error_info_t info;
         } warning_info;
     } u;
     // not allowed inside union


### PR DESCRIPTION
I've noticed two errors lately that are hard to debug:

1. `PMW_WRONG_TYPE`: When this occurs we don't show what the actual type was, only the expected type. This makes it hard to figure out where the bug may exist. I've added the actual type to the event we send to user space. 

2. `PMW_FILLED_EVENTS`: We assume that any error from pushing events to `incomplete_events` is due to the map being full. This is not necessarily the case, there could be other things going on there. I've added the errno to the event we send to user space. I have also increased the buffer from 1K to 8K number of incomplete events. Each incomplete event is 24 bytes so the extra 168KB (24 * 7K) isn't going to hurt anything. 