### PR TITLE
introduce make dev so the programs can be easily made in dev machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SRC = src
 SRCS = $(wildcard $(SRC)/*.c)
 OBJS = $(patsubst $(SRC)/%.c,$(SRC)/%,$(SRCS))
 OBJS_WRAPPED = $(OBJS)
-CLANG_VER = 8
+CLANG_VER ?= 8
 CC = clang-$(CLANG_VER)
 LLC = llc-$(CLANG_VER)
 OPT = opt-$(CLANG_VER)
@@ -26,6 +26,11 @@ CFLAGS += \
 	-fno-stack-protector \
 	-Xclang -disable-llvm-passes \
 	-O2
+
+ifeq ($(shell test $(CLANG_VER) -gt 10; echo $$?),0)
+  CFLAGS += \
+	-Wno-frame-address
+endif
 
 ifeq ($(ARCH),aarch64)
 CFLAGS += \
@@ -97,6 +102,7 @@ $(OBJS): %: %.c
 all: depends check_headers $(OBJDIR) wrapper no_wrapper
 	@:
 
-
+dev:
+	KERNEL_HEADER_VERSION=$(shell uname -r) CLANG_VER=14 $(MAKE) all
 
 .PHONY: all realclean clean ebpf ebpf_verifier depends check_headers

--- a/src/script-events.c
+++ b/src/script-events.c
@@ -150,7 +150,6 @@ int kprobe__handle_pwd(struct pt_regs *ctx)
     u32 skipped = 0;
     script_message_t sev = {0};
     pscript_message_t ev = &sev;
-    unsigned long long ret = 0;
 
     // if the ID already exists, we are tail-calling into ourselves, skip ahead to reading the path
     u64 p_t = bpf_get_current_pid_tgid();
@@ -203,7 +202,7 @@ Send:
     skipped = 0;
     bpf_map_update_elem(&read_path_skip, &skipped, &to_skip, BPF_ANY);
     // tail call back in
-    ret = bpf_tail_call(ctx, &tail_call_table, HANDLE_PWD);
+    bpf_tail_call(ctx, &tail_call_table, HANDLE_PWD);
 
 Skip:
     skipped = 0;

--- a/src/types.h
+++ b/src/types.h
@@ -4,6 +4,7 @@
 
 #include <linux/types.h>
 #include <linux/limits.h>
+#include <linux/version.h>
 
 #define MAX_ADDRESSES 16
 #define TRUE 1
@@ -343,6 +344,7 @@ typedef struct
     char strings[];
 } process_message_t, *pprocess_message_t;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,3,0)
 // clone3 args are not available in sched.h until 5.3, and we build against 4.4
 struct clone_args
 {
@@ -360,6 +362,7 @@ struct clone_args
     // version 3
     __aligned_u64 cgroup;
 };
+#endif
 
 typedef enum
 {

--- a/src/wpm-events.c
+++ b/src/wpm-events.c
@@ -163,7 +163,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_process_vm_writev_5_5,
     DECLARE_EVENT(write_process_memory_event_t, SP_PROCESS_VM_WRITEV);
     ev.target_pid = target_pid;
 
-#pragma unroll
+#pragma unroll MAX_ADDRESSES
     for (u32 ii = 0; ii < MAX_ADDRESSES && ii < riovcnt; ++ii, riov++)
     {
         iovec_t remote_iov;


### PR DESCRIPTION
I think there's a question on whether it is valuable for us to keep building with such old clang + llvm. The tricky part and the part we cannot change is using the 4.11 kernel headers so we aren't adding breaking changes but building with old clang/llvm may actually be keeping us from fixes/optimizations in the compiler. Anyway this PR doesn't address that but I want us to be thinking about that. 