### PR TITLE
Use exe and args from task struct

### DIFF
--- a/src/offsets.h
+++ b/src/offsets.h
@@ -22,6 +22,12 @@ const u64 CRC_TASK_STRUCT_MM = 0xce718bb9d7fe31a2;
 /* mm_struct->exe_file */
 const u64 CRC_MM_STRUCT_EXE_FILE = 0x3ac4a1974916ed95;
 
+/* mm_struct->arg_start */
+const u64 CRC_MM_STRUCT_ARG_START = 0xbf4ac23cfb9bfcdc;
+
+/* mm_struct->arg_end */
+const u64 CRC_MM_STRUCT_ARG_END = 0x5a7beb317405d4d2;
+
 /* file->f_path */
 const u64 CRC_FILE_F_PATH = 0xf1d5510f86260be;
 

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -273,15 +273,6 @@ static __always_inline int fill_syscall(syscall_info_t *syscall_info, void *ts, 
     return 0;
 }
 
-// returns the running executable on the task struct
-static __always_inline void *get_current_exe(void *mmptr)
-{
-    void *ptr = NULL;
-    read_value(mmptr, CRC_MM_STRUCT_EXE_FILE, &ptr, sizeof(ptr));
-
-    return ptr;
-}
-
 // it's argument should be a pointer to a file
 static __always_inline file_info_t extract_file_info(void *ptr)
 {

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -439,7 +439,7 @@ static __always_inline void exit_exec(struct pt_regs *ctx, process_message_type_
     u32 offset = sizeof(process_message_t);
     pm->u.syscall_info.data.exec_info.buffer_length = offset;
     if (bpf_probe_read(&buffer->buf[offset], argv_length, (void *)arg_start) < 0) {
-        ret = -PMW_UNEXPECTED;
+        ret = -PMW_READ_ARGV;
         goto Done;
     }
 

--- a/src/types.h
+++ b/src/types.h
@@ -256,6 +256,10 @@ typedef struct
         {
             u32 buffer_length;
             file_info_t file_info;
+            // send the length of argv we are processing. This is
+            // necessary because unlike paths, argvs can have empty
+            // strings so we cannot rely on double null separators
+            u32 argv_len;
         } exec_info;
     } data;
 } syscall_info_t, *psyscall_info_t;

--- a/src/types.h
+++ b/src/types.h
@@ -241,6 +241,20 @@ typedef struct
 
 typedef struct
 {
+    // whether argv_length is truncated from the actual length. This
+    // is just here so userspace knows that the argv sent is not the
+    // entirety of the argv but just our best effort.
+    u8 argv_truncated;
+    // send the length of argv we are processing. This is
+    // necessary because unlike paths, argvs can have empty
+    // strings so we cannot rely on double null separators
+    u16 argv_length;
+    u32 buffer_length;
+    file_info_t file_info;
+} exec_info_t;
+
+typedef struct
+{
     u32 pid;
     u32 ppid;
     u32 luid;
@@ -252,15 +266,7 @@ typedef struct
     {
         u32 unshare_flags;
         clone_info_t clone_info;
-        struct
-        {
-            u32 buffer_length;
-            file_info_t file_info;
-            // send the length of argv we are processing. This is
-            // necessary because unlike paths, argvs can have empty
-            // strings so we cannot rely on double null separators
-            u32 argv_len;
-        } exec_info;
+        exec_info_t  exec_info;
     } data;
 } syscall_info_t, *psyscall_info_t;
 
@@ -318,8 +324,6 @@ typedef struct
 
 typedef enum
 {
-    SYS_EXECVE_4_11,
-    SYS_EXECVEAT_4_11,
     RET_SYS_EXECVEAT_4_8,
     RET_SYS_EXECVE_4_8,
     SYS_EXEC_PWD,

--- a/src/types.h
+++ b/src/types.h
@@ -254,7 +254,6 @@ typedef struct
         clone_info_t clone_info;
         struct
         {
-            u64 event_id;
             u32 buffer_length;
             file_info_t file_info;
         } exec_info;
@@ -313,6 +312,16 @@ typedef struct
     char truncated;
 } telemetry_value_t;
 
+typedef enum
+{
+    SYS_EXECVE_4_11,
+    SYS_EXECVEAT_4_11,
+    RET_SYS_EXECVEAT_4_8,
+    RET_SYS_EXECVE_4_8,
+    SYS_EXEC_PWD,
+    HANDLE_PWD,
+} tail_call_slot_t;
+
 typedef union
 {
     int err;
@@ -323,6 +332,7 @@ typedef union
         u64 end;
     } argv;
     u64 total_len;
+    tail_call_slot_t tailcall;
 } error_info_t;
 
 typedef struct
@@ -331,15 +341,6 @@ typedef struct
     union
     {
         syscall_info_t syscall_info;
-        struct
-        {
-            u64 event_id;
-            u32 buffer_length;
-        } string_info;
-        struct
-        {
-            u64 event_id;
-        } discard_info;
         struct
         {
             process_message_warning_t code;
@@ -371,17 +372,6 @@ struct clone_args
     __aligned_u64 cgroup;
 };
 #endif
-
-typedef enum
-{
-    SYS_EXECVE_4_11,
-    SYS_EXECVEAT_4_11,
-    RET_SYS_EXECVEAT_4_8,
-    RET_SYS_EXECVE_4_8,
-    SYS_EXECVE_TC_ARGV,
-    SYS_EXECVEAT_TC_ARGV,
-    HANDLE_PWD,
-} tail_call_slot_t;
 
 typedef enum
 {

--- a/src/types.h
+++ b/src/types.h
@@ -88,17 +88,13 @@ typedef enum
     PMW_BUFFER_FULL = 1,
     PMW_TAIL_CALL_MAX,
     PMW_MAX_PATH,
-    PMW_EXEC_TIDS,
     PMW_UPDATE_MAP_ERROR,
     PMW_PID_TGID_MISMATCH,
     PMW_UNEXPECTED,
-    PMW_MISSING_EVENT,
     PMW_READ_PATH_STRING,
-    PMW_READ_ARGV_STRING,
-    PMW_READ_FILENAME_STRING,
+    PMW_READ_ARGV,
     PMW_MISSING_EXE,
     PMW_READING_FIELD,
-    PMW_ARGV_TOO_BIG,
     PMW_ARGV_INCONSISTENT,
 } process_message_warning_t;
 
@@ -114,8 +110,6 @@ typedef enum
     PM_VFORK,
     PM_EXECVE,
     PM_EXECVEAT,
-    PM_STRINGS,
-    PM_DISCARD,
     PM_WARNING,
 } process_message_type_t;
 

--- a/src/types.h
+++ b/src/types.h
@@ -98,6 +98,8 @@ typedef enum
     PMW_READ_FILENAME_STRING,
     PMW_MISSING_EXE,
     PMW_READING_FIELD,
+    PMW_ARGV_TOO_BIG,
+    PMW_ARGV_INCONSISTENT,
 } process_message_warning_t;
 
 typedef enum
@@ -316,6 +318,11 @@ typedef union
     int err;
     u64 stored_pid_tgid;
     u64 offset_crc;
+    struct {
+        u64 start;
+        u64 end;
+    } argv;
+    u64 total_len;
 } error_info_t;
 
 typedef struct


### PR DESCRIPTION
Alright this is one is a biggie:

We cannot rely on user input in the exec* syscalls for exename and argv. In particular, we cannot rely on this because the kernel overwrites them for cases such as interpreted scripts (e.g., bash scripts). So we are now going to rely on the data inside the `task_struct` in the `kretprobe` of exec* syscalls to gather all that data. This actually simplifies a lot of logic:

* `execveat` and `execve` are now exactly the same.
* We no longer need to pass incomplete data from kprobe to neither user space not to kretprobe for exec syscalls. All the information we want is in the `kretprobe` so there is nothing for the `kprobe` to do. 
* The kernel when it copies the `argv` it puts it all into a contiguous buffer and it knows the `arg_start` and `arg_end`. As far as I can tell the kernel itself relies on this: https://elixir.bootlin.com/linux/v4.11/source/mm/util.c#L629. Because of this we can now just copy the entire thing in one go rather than loop. This greatly improves our performance. This also helps us fix a bug we hadn't noticed before: because we relied on double null separators arguments of empty strings would make us stop the parsing early and not parse the entire argv. 

Additionally I added an improvement that let's us traverse our path trees without the skipping logic by keeping track of the dentry pointer itself. 