### PR TITLE
Get real mountpoint

### DIFF
--- a/src/offsets.h
+++ b/src/offsets.h
@@ -34,6 +34,9 @@ const u64 CRC_FILE_F_PATH = 0xf1d5510f86260be;
 /* path->dentry */
 const u64 CRC_PATH_DENTRY = 0x71a4a97d6a6791a9;
 
+/* path->mnt */
+const u64 CRC_PATH_MNT = 0x88c40f5cf27266ae;
+
 /* dentry->d_name */
 const u64 CRC_DENTRY_D_NAME = 0x1b807e513eab1323;
 
@@ -117,3 +120,9 @@ const u64 CRC_LINUX_BINPRM_FILENAME = 0xb583ce53935255c5;
 
 /* linux_binprm->interp */
 const u64 CRC_BPRM_INTERP = 0x9f4cedeb0b40dc2c;
+
+/* mount->mnt */
+const u64 CRC_MOUNT_MNT = 0x332c1523b7204177;
+
+/* mount->mnt_mountpoint */
+const u64 CRC_MOUNT_MOUNTPOINT = 0x497e95c14e2d950;

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -23,7 +23,7 @@
 // TODO: make programs for newer kernels where we can use higher values
 
 // maximum segments we can read from a d_path before doing a tail call
-#define MAX_PATH_SEGMENTS_NOTAIL 12
+#define MAX_PATH_SEGMENTS_NOTAIL 32
 
 // these structs are used to send data gathered/calculated in a kprobe
 // to the kretprobe.


### PR DESCRIPTION
I recommend looking at this commit by commit

1. Cleans up how we handle sending warnings to userspace. Our code was getting very messy passing an "error info" all over the place so different spots can set it. It was also complicated by the fact that sometimes a warning doesn't mean we should  not send the message for the syscall but the warning and the message shared a buffer so we would have to be careful not to accidentally override stuff and in fact I think we were overriding some data accidentally. This commit adds a "cpu local" warning using per cpu arrays with a size of 1. This way if at any point we need to save data about a warning to send later we can just update that "cpu local" warning. This does mean that we are potentially doing more instructions and perhaps a slightly bigger stack but our recent improvements have reduced our instruction set substantially so I think the cost of the extra instructions is not too bad. 

2. Changes the dentry cache to mantain two dentries, a path dentry and a mountpoint dentry. This commit just is essentially a no-op since it never sets nor reads the mountpoint dentry.

3. Sets the mountpoint dentry and uses it to get a more "real" path to an executable or pwd. The logic in here is as follows:
     1. Initialize the dentry pair with both a path and a mountpoint dentry
     2. Process the path dentry until we are at its "root" (i.e., parent pointer is null or points to the same dentry)
     3. Replace the path dentry with the mountpoint dentry and set the mountpoint dentry to `NULL`. Continue processing the path dentry that is now the path to the mountpoint. 
     4. When the path the mountpoint is at its root then we are done
  
4. Increased the amount of path segments the ebpf programs will attempt to process before tail-calling from 32. This gives us ~3000 instructions so we still have room to add more if we need to. 