### PR TITLE
handle recursive mounts and mountroots not at "/"

### DIFF
--- a/src/offsets.h
+++ b/src/offsets.h
@@ -126,3 +126,9 @@ const u64 CRC_MOUNT_MNT = 0x332c1523b7204177;
 
 /* mount->mnt_mountpoint */
 const u64 CRC_MOUNT_MOUNTPOINT = 0x497e95c14e2d950;
+
+/* mount->mnt_parent */
+const u64 CRC_MOUNT_MNTPARENT = 0x57a4eea49a711d75;
+
+/* vfsmount->mnt_root */
+const u64 CRC_VFSMOUNT_MNTROOT = 0xe4baf16bf0b472fa;

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -206,16 +206,6 @@ static __always_inline void* read_field_ptr(void *base, u64 field) {
     return dst;
 }
 
-// Equivalent to container_of(ptr, type, member) where field_key is
-// the key for the member offset for the type. If not found the
-// current CPU's warning info is set and NULL is returned.
-static __always_inline void* containerof(void *ptr, u64 field_key) {
-    u32 *offset = get_offset(CRC_MOUNT_MNT);
-    if (offset == NULL) return NULL;
-
-    return ptr - *offset;
-}
-
 static __always_inline void init_cached_path(cached_path_t *cached_path, void *path)
 {
     // cached_path->next_dentry = path->dentry;


### PR DESCRIPTION
I was seeing a weird path when running processes inside a mounted folder inside docker due to our lack of handling "mount roots" properly. 

We were also not handling nested mounts because we were only going one layer deep in the mount instead of looking at that mount's parent. 

The logic now is essentially a simplified version of: https://github.com/torvalds/linux/blob/247f34f7b80357943234f93f247a1ae6b6c3a740/fs/d_path.c#L226 (the main logic being in the helper function: https://github.com/torvalds/linux/blob/master/fs/d_path.c#L103)

Simplified in that it doesn't worry about only going up to an arbitrary "root" (it just goes until the absolute root and that it doesn't handle cases of an unattached namespace). 

The logic is summarized here:

#### Once when starting to process the path 
1. Save the `dentry` (`path->dentry`) and the `vfsmount` (`path->mnt`) of the path in a map that can be used for tail-calling. 

#### Once per tail-call

2. Calculate the `mount` that wraps the `vfsmount`.
3. Calculate the parent `mount` (`mount->mnt_parent`)
4. Calculate the  mount root dentry (`vfsmount->mnt_root`)

#### Once per path segment

5. If the current `dentry` is already at `vfsmount->mnt_root`:
    1. If our current `mount` is the same as our `mount->parent`:
        1. Done processing the path go to global root handling (Step 11).
    2. Change `dentry` to be `mount->mountpoint` as we will now start to process the mountpoint as our path
    3. Set `mount` to be `mount->parent` (also change the variable mnt_parent accordingly)
    4. Change `vfsmount` to be the new `mount->mnt` (this updates the across-tail call cache). Change the mount root dentry variable accordingly.
    5. Continue back from 5.
6. If `dentry == dentry->d_parent`:
    1. We know we aren't at the mount root so our path isn't related to the mount (e.g., it's a memfd). Go to global root  handling (Step 11)
7. Save the `dentry`'s path segment (this updates the across-tail call cache)
8. Set `dentry->d_parent` to be the current `dentry`
9. Continue back from 5

#### End of loop without finding the global root
10. Tail-call which will restart back from 2.

#### At global root
11. Write the root's path segment as we deliberately left the loop without processing the root segment. Expected values here at either `/` or the name of a memfd. 
12. Done

The important parts here is that we only stop when either the `mount`'s parent is itself (so we are the global root) or the dentry's parent is itself and it has no relation to the mountpoint (e.g., a memfd). This allows us to get the paths of multiple mountpoints. We also stop each mountpoint at its virtual fs mount root as that is how the path would be represented externally and how we would be able to find the path. 