### PR TITLE
support kernels where the loginuid is inside an audit_task_info

### DIFF
--- a/src/offsets.h
+++ b/src/offsets.h
@@ -132,3 +132,9 @@ const u64 CRC_MOUNT_MNTPARENT = 0x57a4eea49a711d75;
 
 /* vfsmount->mnt_root */
 const u64 CRC_VFSMOUNT_MNTROOT = 0xe4baf16bf0b472fa;
+
+/* task_struct->audit */
+const u64 CRC_TASK_STRUCT_AUDIT = 0x67da4ab26d333059;
+
+/* audit_task_info->loginuid */
+const u64 CRC_AUDIT_TASK_INFO_LOGINUID = 0xe6dd107ea26da1a0;


### PR DESCRIPTION
in most systems including the latest mainline kernel 6.1-rc loginuid is in `task_struct->loginuid`. In systems that took in [a patch to refactor some of audit](https://github.com/linux-audit/audit-kernel/issues/90), however, it is instead inside `task_struct->audit->loginuid`. One of this systems is Google's Container Optimized OS which is used in GKE. [How the task struct looks in the COS kernel](https://cos.googlesource.com/third_party/kernel/+/f91c175e2862a9e655af7b095a2466531db8270b/include/linux/sched.h#987) + [the audit task info definition]( https://cos.googlesource.com/third_party/kernel/+/f91c175e2862a9e655af7b095a2466531db8270b/include/linux/audit.h#122).

The mainline kernel hasn't taken this patch in yet so the final form may change and we may need to add another special case if/when that happens. 

This PR makes the absence of `task_struct->loginuid` not a hard stop and instead then checks for `audit` inside the task. If `audit` is missing and `loginuid` is missing then we will return a warning to userspace as we expect either or. Our philosophy right now is that we rather warn loudly instead of passing incorrect data (An empty loginuid implies it was run by a cron job or something which would be incorrect if we just simply happened to be missing it because we didn't grab the right field). 