### PR TITLE
Script error handling

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -76,9 +76,12 @@ static __always_inline int read_value(void *base, u64 offset, void *dest, size_t
     __builtin_memcpy(&event, (void *)__eventp, sizeof(ty)); \
     if (event.key != key) goto EventMismatch;
 
-// returns NULL if offsets have not yet been loaded
-static __always_inline void *offset_loaded()
+// returns 0 if offsets have not yet been loaded
+static __always_inline u32 offset_loaded()
 {
     u64 offset = CRC_LOADED;
-    return bpf_map_lookup_elem(&offsets, &offset);
+    u32 *loaded = bpf_map_lookup_elem(&offsets, &offset);
+
+    if (loaded == NULL) { return 0; }
+    return *loaded;
 }

--- a/src/process/script.h
+++ b/src/process/script.h
@@ -160,8 +160,12 @@ static __always_inline void enter_script(struct pt_regs *ctx, void *bprm) {
  NoEvent:;
   // first time saving a script for this exec*
   if (filename != interp) {
-    set_empty_local_warning(PMW_INTERP_MISMATCH);
-    goto EmitWarning;
+    // if they don't match but we do not have an existing incomplete
+    // event then it most likely means that the program was loaded
+    // right in between two load_script calls. We can't really know
+    // for sure what information was in the initial load_script so we
+    // should just skip this.
+    return;
   }
 
   event = (script_t){0};

--- a/src/process/script.h
+++ b/src/process/script.h
@@ -75,6 +75,8 @@ struct bpf_map_def SEC("maps/rel_interpreters") rel_interpreters = {
 };
 
 static __always_inline void enter_script(struct pt_regs *ctx, void *bprm) {
+  if (!offset_loaded()) return;
+
   u32 key = 0;
   buf_t *buffer = (buf_t *)bpf_map_lookup_elem(&buffers, &key);
   if (buffer == NULL) return;

--- a/src/process/script.h
+++ b/src/process/script.h
@@ -188,7 +188,7 @@ static __always_inline void enter_script(struct pt_regs *ctx, void *bprm) {
 
  EventMismatch:;
   error_info_t info = {0};
-  info.stored_pid_tgid = (((u64) event.pid) << 32) & (event.pid);
+  info.stored_pid_tgid = (((u64) event.pid) << 32) | (event.pid);
   set_local_warning(PMW_PID_TGID_MISMATCH, info);
 
  EmitWarning:;
@@ -274,7 +274,7 @@ static __always_inline u64 push_scripts(struct pt_regs *ctx, buf_t *buffer) {
 
  EventMismatch:;
   error_info_t info = {0};
-  info.stored_pid_tgid = (((u64) event.pid) << 32) & (event.pid);
+  info.stored_pid_tgid = (((u64) event.pid) << 32) | (event.pid);
   set_local_warning(PMW_PID_TGID_MISMATCH, info);
 
  EmitWarning:;


### PR DESCRIPTION
This PR tries address a couple of warnings we've been seeing with script events:

* `PMW_INTERP_MISMATCH`: This warning is emitted when we the first "load_script" event we see for a pid has an interpreter that is different than the original file. During an `exec` the `interp` field is set to be the same thing as the `filename` before the first call to `load_script`. The `interpreter` can then be changed based on whether a script was being executed or not and if so future calls to `load_script` for the same exec event will have a different interpreter until we get an interpreter that is no longer a script (capping at 4 attempts). Because of this we had code to check that `filename` matched `interp` because otherwise there was a violation of something we considered an invariant. In practice, however, we see this happen with semi regularity because a script could start its exec syscall before the program our eBPF program is loaded, but finish after our eBPF program has loaded. In this case we may have missed the first call to `load_script` but got the second (or third, fourth, ...) and thus the first `load_script` we saw didn't have an `interp` that matched the `filename`. This meant this warning was triggered even though there was nothing wrong with our code, we were just looking at an event that started right before we loaded the program.

* `PMW_PID_TGID_MISMATCH`: This warning is emitted whenever a map's key is not consistent with its value. Whenever we save an event in a map we save its key as part of its value to make sure that we are actually loading the right value as we had noticed some inconsistencies (presumably a race condition in maps that are not per-cpu). Whenever we load a value we check that the "key" we saved as part of the value is the same as the key of the map and emit a warning otherwise. I've noticed this happen quite a bit more often on scripts than other events (i.e., clone + unshare), my guess is that it might be because script events are recursive (or at least iterative in newer kernels) and thus can happen multiple times per syscall leading to a bigger chance of a race condition. I don't know how to fix this fully yet so for now I have implemented a simple retry-once. Also I noticed that the value we were saving as the "stored" key was always coming back as 0 for script load so I fixed that silly bug by changing the `&` into a `|` when composing the `pid_tgid` from a `pid`. 

* `PMW_READING_FIELD`: This warning is emitted whenever we try to read a field from our offset map but for some reason we can't find it. In scripts we were not checking for the "loaded" value before attempting to load other fields making this happen more often. I have also changed the check to verify not just the existence of the value but that it is also > 0 such that userspace can set this back to 0 as a way to mark it as not loaded before starting to bring down the programs to prevent this warning being emitted during tear down. 