### PR TITLE
Support for script load events on kernels < 4.18

### DIFF
--- a/src/bpf_helpers.h
+++ b/src/bpf_helpers.h
@@ -233,6 +233,8 @@ static unsigned long long (*bpf_get_current_task)(void) =
     (void *)BPF_EXT_FUNC_get_current_task;
 static unsigned long long (*bpf_tail_call)(void *ctx, void *map, int index) =
     (void *)BPF_EXT_FUNC_tail_call;
+static u64 (*bpf_get_current_cgroup_id)(void) =
+    (void *)BPF_EXT_FUNC_get_current_cgroup_id;
 
 /* llvm builtin functions that eBPF C program may use to
  * emit BPF_LD_ABS and BPF_LD_IND instructions

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -25,18 +25,34 @@ int kprobe__sys_exec_pwd(struct pt_regs *ctx)
     return 0;
 }
 
-SEC("kretprobe/ret_sys_execve_4_8")
-int kretprobe__ret_sys_execve_4_8(struct pt_regs *ctx)
+SEC("kretprobe/ret_sys_execve")
+int kretprobe__ret_sys_execve(struct pt_regs *ctx)
 {
-    exit_exec(ctx, PM_EXECVE, RET_SYS_EXECVE_4_8);
+    exit_exec(ctx, PM_EXECVE, bpf_get_current_cgroup_id(), RET_SYS_EXECVE);
 
     return 0;
 }
 
-SEC("kretprobe/ret_sys_execveat_4_8")
-int kretprobe__ret_sys_execveat_4_8(struct pt_regs *ctx)
+SEC("kretprobe/ret_sys_execveat")
+int kretprobe__ret_sys_execveat(struct pt_regs *ctx)
 {
-    exit_exec(ctx, PM_EXECVEAT, RET_SYS_EXECVEAT_4_8);
+    exit_exec(ctx, PM_EXECVEAT, bpf_get_current_cgroup_id(), RET_SYS_EXECVEAT);
+
+    return 0;
+}
+
+SEC("kretprobe/ret_sys_execve_pre_4_18")
+int kretprobe__ret_sys_execve_pre_4_18(struct pt_regs *ctx)
+{
+    exit_exec(ctx, PM_EXECVE, 0, RET_SYS_EXECVE);
+
+    return 0;
+}
+
+SEC("kretprobe/ret_sys_execveat_pre_4_18")
+int kretprobe__ret_sys_execveat_pre_4_18(struct pt_regs *ctx)
+{
+    exit_exec(ctx, PM_EXECVEAT, 0, RET_SYS_EXECVEAT);
 
     return 0;
 }

--- a/src/process/exec.h
+++ b/src/process/exec.h
@@ -8,7 +8,7 @@
 #include "script.h"
 
 static __always_inline void exit_exec(struct pt_regs *ctx, process_message_type_t pm_type,
-                                      tail_call_slot_t tail_call)
+                                      u64 cgroup_id, tail_call_slot_t tail_call)
 {
     /* SETUP ALL THE VARIABLES THAT WILL BE NEEDED ACCROSS GOTOS */
     u32 key = 0;
@@ -70,6 +70,7 @@ static __always_inline void exit_exec(struct pt_regs *ctx, process_message_type_
 
     pm->type = pm_type;
     pm->u.syscall_info.retcode = retcode;
+    pm->u.syscall_info.data.exec_info.cgroup_id = cgroup_id;
     if (extract_file_info(exe, &pm->u.syscall_info.data.exec_info.file_info) < 0) goto EmitWarning;
 
     // TODO: handle error

--- a/src/types.h
+++ b/src/types.h
@@ -232,6 +232,7 @@ typedef struct
     u16 argv_length;
     u32 buffer_length;
     u64 event_id;
+    u64 cgroup_id;
     file_info_t file_info;
     char comm[TASK_COMM_LEN];
 } exec_info_t;
@@ -296,8 +297,8 @@ typedef struct
 
 typedef enum
 {
-    RET_SYS_EXECVEAT_4_8,
-    RET_SYS_EXECVE_4_8,
+    RET_SYS_EXECVEAT,
+    RET_SYS_EXECVE,
     SYS_EXEC_PWD,
     HANDLE_PWD,
 } tail_call_slot_t;


### PR DESCRIPTION
On kernels prior to 4.18 we are not allowed to use values of a map as values of a different map. In the script load events we were doing this to avoid having to keep the interpreter path on our stack since we are limited to 512 bytes and I was reaching that limit when I was first implementing script load a few weeks ago. 

Since then it looks like some of the recent changes we have done have managed to reduce our stack just enough to where we are able to keep the interpreter path in the stack using in total only 440 bytes. This does mean we *only* have 72 bytes of wiggle room if we need to make more changes to the script load program but I think that's okay for now if we need to address that later then we can figure something out later (e.g., make a new program for kernels below 4.18 that use a smaller buffer for the interpreter path since in older kernels the max size is 128 bytes but we are using 256 bytes because that's what newer kernels allow). 

Additionally, I've added the cgroup id as part of the data that exec events emit to userspace for kernels 4.18+. The cgroup id is the `inode` of the cgroup such that something like this can find the right cgroup path in userspace:

```
$ find /sys/fs/cgroup/ -inum 95332 #where 95332 is the cgroup id
/sys/fs/cgroup/system.slice/docker-44854c22afa7ef395a850f5ceb3952d6f60521923580902f13697028108599d5.scope
```

This is an initial step towards making cgroup more reliable (although still not fool proof even on newer kernels due to TOCTOU issues with when we get the cgroup id vs when we'd query for the path). 

For older kernels I've added new exec* programs that do not try to get the cgroup id and just pass `0` to the extracted function. Userspace can assume `0` means we were not able to get the `cgroup` since inode 0 is not a valid inode for an existing file. 