### PR TITLE
Initial filemod support monitoring mkdir calls

### DIFF
--- a/src/file-events.c
+++ b/src/file-events.c
@@ -133,9 +133,10 @@ static __always_inline void store_dentry(struct pt_regs *ctx, void *dentry)
     u64 pid_tgid = bpf_get_current_pid_tgid();
 
     load_event(incomplete_mkdirs, pid_tgid, incomplete_mkdir_t);
-    if (event.target_dentry == NULL)
+    if (event.target_dentry == NULL) {
         event.target_dentry = dentry;
-    bpf_map_update_elem(&incomplete_mkdirs, &pid_tgid, &event, BPF_ANY);
+        bpf_map_update_elem(&incomplete_mkdirs, &pid_tgid, &event, BPF_ANY);
+    }
     return;
 
     EventMismatch:;

--- a/src/file-events.c
+++ b/src/file-events.c
@@ -12,7 +12,7 @@
 #include "process/path.h"
 #include "process/warning.h"
 
-// The map where process event messages get emitted to
+// The map where file event messages get emitted to
 struct bpf_map_def SEC("maps/file_events") file_events = {
     .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
     .key_size = sizeof(u32),

--- a/src/file-events.c
+++ b/src/file-events.c
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: GPL-2.0+
+
+#include <linux/kconfig.h>
+#include <linux/version.h>
+#include <linux/fs.h>
+#include "bpf_helpers.h"
+#include "types.h"
+#include "offsets.h"
+#include "common.h"
+#include "process/helpers.h"
+#include "process/buffer.h"
+#include "process/path.h"
+#include "process/warning.h"
+
+// The map where process event messages get emitted to
+struct bpf_map_def SEC("maps/file_events") file_events = {
+    .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
+    .key_size = sizeof(u32),
+    .value_size = sizeof(u32),
+    .max_entries = 0, // let oxidebpf set it to num_cpus
+    .pinning = 0,
+    .namespace = "",
+};
+
+// pushes a message to the file_events perfmap for the current CPU.
+static __always_inline int push_file_message(struct pt_regs *ctx, file_message_t *fm)
+{
+    return bpf_perf_event_output(ctx, &file_events, BPF_F_CURRENT_CPU, fm, sizeof(*fm));
+}
+
+// pushes a message with an extra `dynamic_size` number of bytes. It
+// will never send more than `MAX_PERCPU_BUFFER` number of bytes. It
+// is a *bug* if dynamic_size here is larger than MAX_PERCPU_BUFFER
+// and it will cause the number of bytes to to dynamic_size %
+// MAX_PERCPU_BUFFER.
+static __always_inline int push_flexible_file_message(struct pt_regs *ctx, file_message_t *ev, u64 dynamic_size)
+{
+    // The -1 and +1 logic is here to prevent a buffer that is exactly
+    // MAX_PERCPU_BUFFER size to become 0 due to the bitwise AND. We
+    // know that dynamic_size will never be 0 so this is safe.
+    u64 size_to_send = ((dynamic_size - 1) & (MAX_PERCPU_BUFFER - 1)) + 1;
+    return bpf_perf_event_output(ctx, &file_events, BPF_F_CURRENT_CPU, ev, size_to_send);
+}
+
+// pushes a warning to the process_events perfmap for the current CPU.
+static __always_inline int push_file_warning(struct pt_regs *ctx, file_message_t *fm,
+                                             file_message_type_t fm_type)
+{
+    fm->type = FM_WARNING;
+    message_type_t m_type;
+    m_type.file = fm_type;
+
+    load_warning_info(&fm->u.warning, m_type);
+
+    return push_file_message(ctx, fm);
+}
+
+// its argument should be a pointer to a dentry
+static __always_inline int extract_file_info_owner(void *ptr, file_info_t *file_info, file_ownership_t *file_owner)
+{
+    void *d_inode = read_field_ptr(ptr, CRC_DENTRY_D_INODE);
+    if (d_inode == NULL) return -1;
+
+    void *i_sb = read_field_ptr(d_inode, CRC_INODE_I_SB);
+    if (i_sb == NULL) return -1;
+
+    // inode
+    if (read_field(d_inode, CRC_INODE_I_INO, &file_info->inode, sizeof(file_info->inode)) < 0)
+        return -1;
+
+    // device major/minor
+    u32 i_dev = 0;
+    if (read_field(i_sb, CRC_SBLOCK_S_DEV, &i_dev, sizeof(i_dev)) < 0) return -1;
+
+    file_info->devmajor = MAJOR(i_dev);
+    file_info->devminor = MINOR(i_dev);
+
+    // uid/gid/mode
+    if (read_field(d_inode, CRC_INODE_I_UID, &file_owner->uid, sizeof(file_owner->uid)) < 0)
+        return -1;
+    if (read_field(d_inode, CRC_INODE_I_GID, &file_owner->gid, sizeof(file_owner->gid)) < 0)
+        return -1;
+    if (read_field(d_inode, CRC_INODE_I_MODE, &file_owner->mode, sizeof(file_owner->mode)) < 0)
+        return -1;
+
+    return 0;
+}
+
+typedef struct {
+  u64 pid_tgid;
+  u64 start_ktime_ns;
+  void *target_dentry;
+} incomplete_mkdir_t;
+
+// A map of mkdirs that have started (a kprobe) but are yet to finish
+// (the kretprobe).
+struct bpf_map_def SEC("maps/incomplete_mkdir") incomplete_mkdirs = {
+  .type = BPF_MAP_TYPE_LRU_HASH,
+  .key_size = sizeof(u64),
+  .value_size = sizeof(incomplete_mkdir_t),
+  .max_entries = 256,
+  .pinning = 0,
+  .namespace = "",
+};
+
+static __always_inline void enter_mkdir(struct pt_regs *ctx)
+{
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    incomplete_mkdir_t event = {0};
+    event.pid_tgid = pid_tgid;
+    event.start_ktime_ns = bpf_ktime_get_ns();
+
+    int ret = bpf_map_update_elem(&incomplete_mkdirs, &pid_tgid, &event, BPF_ANY);
+    if (ret < 0)
+    {
+        file_message_t fm = {0};
+        fm.type = FM_WARNING;
+        fm.u.warning.pid_tgid = pid_tgid;
+        fm.u.warning.message_type.file = FM_CREATE;
+        fm.u.warning.code = W_UPDATE_MAP_ERROR;
+        fm.u.warning.info.err = ret;
+
+        push_file_message(ctx, &fm);
+
+        return;
+    }
+
+    return;
+}
+
+static __always_inline void store_dentry(struct pt_regs *ctx, void *dentry)
+{
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    error_info_t info = {0};
+
+    load_event(incomplete_mkdirs, pid_tgid, incomplete_mkdir_t);
+    event.target_dentry = dentry;
+    bpf_map_update_elem(&incomplete_mkdirs, &pid_tgid, &event, BPF_ANY);
+
+    EventMismatch:
+    info.stored_pid_tgid = event.pid_tgid;
+    set_local_warning(W_PID_TGID_MISMATCH, info);
+    return;
+
+    NoEvent:
+    return;
+}
+
+static __always_inline void exit_mkdir(struct pt_regs *ctx, tail_call_slot_t tail_call)
+{
+    u32 key = 0;
+    buf_t *buffer = (buf_t *)bpf_map_lookup_elem(&buffers, &key);
+    if (buffer == NULL) return;
+
+    cached_path_t *cached_path = (cached_path_t *)bpf_map_lookup_elem(&percpu_path, &key);
+    if (cached_path == NULL) return;
+
+    file_message_t *fm = (file_message_t *)buffer;
+    cursor_t cursor = { .buffer = buffer, .offset = &fm->u.action.buffer_len };
+    int ret = 0;
+    error_info_t info = {0};
+
+    if (cached_path->next_dentry != NULL) goto ResolveName;
+
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    load_event(incomplete_mkdirs, pid_tgid, incomplete_mkdir_t);
+    ret = extract_file_info_owner(event.target_dentry, &fm->u.action.target, &fm->u.action.target_owner);
+    if (ret < 0) goto EmitWarning;
+
+    fm->type = FM_CREATE;
+    fm->u.action.pid = event.pid_tgid >> 32;
+    fm->u.action.mono_ns = event.start_ktime_ns;
+    fm->u.action.buffer_len = sizeof(file_message_t);
+    fm->u.action.u.create.source_link = LINK_NONE;
+
+    cached_path->next_dentry = event.target_dentry;
+
+    ResolveName:
+    ret = write_path(ctx, cached_path, &cursor, tail_call);
+    cached_path->next_dentry = NULL;
+    if (ret < 0) goto EmitWarning;
+
+    write_null_char(cursor.buffer, cursor.offset);
+    push_flexible_file_message(ctx, fm, *cursor.offset);
+    return;
+
+    EventMismatch:
+    info.stored_pid_tgid = event.pid_tgid;
+    set_local_warning(W_PID_TGID_MISMATCH, info);
+
+    EmitWarning:
+    push_file_warning(ctx, fm, FM_CREATE);
+    return;
+
+    NoEvent:
+    return;
+}
+
+SEC("kprobe/sys_mkdir")
+int BPF_KPROBE_SYSCALL(kprobe__sys_mkdir) {
+    enter_mkdir(ctx);
+    return 0;
+}
+
+SEC("kprobe/sys_mkdirat")
+int BPF_KPROBE_SYSCALL(kprobe__sys_mkdirat) {
+    enter_mkdir(ctx);
+    return 0;
+}
+SEC("kprobe/security_inode_mkdir")
+int BPF_KPROBE(security_inode_mkdir, struct inode *dir, struct dentry *dentry, umode_t mode) {
+    store_dentry(ctx, (void *)dentry);
+    return 0;
+}
+
+SEC("kretprobe/ret_do_mkdirat")
+int BPF_KRETPROBE(do_mkdirat, int retval) {
+    if (retval < 0) return 0;
+    exit_mkdir(ctx, RET_DO_MKDIRAT);
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";
+uint32_t _version SEC("version") = 0xFFFFFFFE;

--- a/src/offsets.h
+++ b/src/offsets.h
@@ -40,6 +40,9 @@ const u64 CRC_PATH_MNT = 0x88c40f5cf27266ae;
 /* dentry->d_name */
 const u64 CRC_DENTRY_D_NAME = 0x1b807e513eab1323;
 
+/* dentry->d_inode */
+const u64 CRC_DENTRY_D_INODE = 0x3A4154E1EBE3C516;
+
 /* qstr->hash_len */
 const u64 CRC_QSTR_HASH_LEN = 0xeb88a6081906b367;
 
@@ -60,6 +63,15 @@ const u64 CRC_INODE_FS = 0x61ac74b5c543f248;
 
 /* inode->i_sb */
 const u64 CRC_INODE_I_SB = 0x861dc69e083a70b5;
+
+/* inode->i_mode */
+const u64 CRC_INODE_I_MODE = 0xC3ECA32D8DB5FBC3;
+
+/* inode->i_uid */
+const u64 CRC_INODE_I_UID = 0x70149101D7E8C934;
+
+/* inode->i_gid */
+const u64 CRC_INODE_I_GID = 0x5353E0ECE03150E1;
 
 /* super_block->s_dev */
 const u64 CRC_SBLOCK_S_DEV = 0xb1c03bec387e1aca;

--- a/src/process/buffer.h
+++ b/src/process/buffer.h
@@ -12,6 +12,14 @@ typedef struct
     char buf[MAX_PERCPU_BUFFER];
 } buf_t;
 
+// a type that points to a buffer and the current write position within
+// that buffer
+typedef struct
+{
+    buf_t *buffer;
+    u32 *offset;
+} cursor_t;
+
 // A per cpu buffer that can hold more data than allowed in the
 // stack. Used to collect data of variable length such as a string.
 struct bpf_map_def SEC("maps/buffers") buffers = {

--- a/src/process/clone.h
+++ b/src/process/clone.h
@@ -40,8 +40,8 @@ static __always_inline void enter_clone(struct pt_regs *ctx, process_message_typ
     process_message_t pm = {0};
     pm.type = PM_WARNING;
     pm.u.warning_info.pid_tgid = pid_tgid;
-    pm.u.warning_info.message_type = pm_type;
-    pm.u.warning_info.code = PMW_UPDATE_MAP_ERROR;
+    pm.u.warning_info.message_type.process = pm_type;
+    pm.u.warning_info.code = W_UPDATE_MAP_ERROR;
     pm.u.warning_info.info.err = ret;
 
     push_message(ctx, &pm);
@@ -79,7 +79,7 @@ static __always_inline void exit_clone(struct pt_regs *ctx, pprocess_message_t p
  EventMismatch:;
   error_info_t info = {0};
   info.stored_pid_tgid = event.pid_tgid;
-  set_local_warning(PMW_PID_TGID_MISMATCH, info);
+  set_local_warning(W_PID_TGID_MISMATCH, info);
 
  EmitWarning:;
   push_warning(ctx, pm, pm_type);

--- a/src/process/helpers.h
+++ b/src/process/helpers.h
@@ -10,7 +10,7 @@ static __always_inline u32* get_offset(u64 field) {
     if (offset == NULL) {
         error_info_t info = {0};
         info.offset_crc = field;
-        set_local_warning(PMW_READING_FIELD, info);
+        set_local_warning(W_READING_FIELD, info);
     }
 
     return offset;
@@ -36,7 +36,7 @@ static __always_inline int read_field(void *base, u64 field, void *dst, size_t s
     if (ret < 0) {
         error_info_t info = {0};
         info.offset_crc = field;
-        set_local_warning(PMW_PTR_FIELD_READ, info);
+        set_local_warning(W_PTR_FIELD_READ, info);
     }
 
     return ret;
@@ -51,7 +51,7 @@ static __always_inline void* read_field_ptr(void *base, u64 field) {
     if (dst == NULL) {
         error_info_t info = {0};
         info.offset_crc = field;
-        set_local_warning(PMW_NULL_FIELD, info);
+        set_local_warning(W_NULL_FIELD, info);
     }
 
     return dst;
@@ -101,7 +101,7 @@ static __always_inline int fill_syscall(syscall_info_t *syscall_info, void *ts, 
         if (bpf_probe_read(&luid, sizeof(luid), ts + *offset) < 0) {
             error_info_t info = {0};
             info.offset_crc = offset_key;
-            set_local_warning(PMW_PTR_FIELD_READ, info);
+            set_local_warning(W_PTR_FIELD_READ, info);
 
             return -1;
         }

--- a/src/process/push_message.h
+++ b/src/process/push_message.h
@@ -1,4 +1,5 @@
 #include "buffer.h"
+#include "warning.h"
 
 #pragma once
 
@@ -30,4 +31,17 @@ static __always_inline int push_flexible_message(struct pt_regs *ctx, pprocess_m
     // know that dynamic_size will never be 0 so this is safe.
     u64 size_to_send = ((dynamic_size - 1) & (MAX_PERCPU_BUFFER - 1)) + 1;
     return bpf_perf_event_output(ctx, &process_events, BPF_F_CURRENT_CPU, ev, size_to_send);
+}
+
+// pushes a warning to the process_events perfmap for the current CPU.
+static __always_inline int push_warning(struct pt_regs *ctx, pprocess_message_t pm,
+                                        process_message_type_t pm_type)
+{
+    pm->type = PM_WARNING;
+    message_type_t m_type;
+    m_type.process = pm_type;
+
+    load_warning_info(&pm->u.warning_info, m_type);
+
+    return push_message(ctx, pm);
 }

--- a/src/process/script.h
+++ b/src/process/script.h
@@ -107,7 +107,7 @@ static __always_inline void enter_script(struct pt_regs *ctx, void *bprm) {
   }
 
   if (new_interpreter == NULL) {
-    set_empty_local_warning(PMW_INTERP_SLOT);
+    set_empty_local_warning(W_INTERP_SLOT);
     goto EmitWarning;
   }
 
@@ -123,7 +123,7 @@ static __always_inline void enter_script(struct pt_regs *ctx, void *bprm) {
   // I don't think we need to worry right now.
   ret = bpf_probe_read_str(&path.path, BINPRM_BUF_SIZE, interp);
   if (ret < 0) {
-    set_empty_local_warning(PMW_READ_PATH_STRING);
+    set_empty_local_warning(W_READ_PATH_STRING);
     goto EmitWarning;
   }
 
@@ -132,7 +132,7 @@ static __always_inline void enter_script(struct pt_regs *ctx, void *bprm) {
     if (ret < 0) {
       error_info_t info = {0};
       info.err = ret;
-      set_local_warning(PMW_UPDATE_MAP_ERROR, info);
+      set_local_warning(W_UPDATE_MAP_ERROR, info);
       goto EmitWarning;
     }
 
@@ -146,7 +146,7 @@ static __always_inline void enter_script(struct pt_regs *ctx, void *bprm) {
     if (ret < 0) {
       error_info_t info = {0};
       info.err = ret;
-      set_local_warning(PMW_UPDATE_MAP_ERROR, info);
+      set_local_warning(W_UPDATE_MAP_ERROR, info);
       goto EmitWarning;
     }
   }
@@ -197,7 +197,7 @@ static __always_inline void enter_script(struct pt_regs *ctx, void *bprm) {
     // of incurring the runtime cost for all the normal cases.
     ret = bpf_probe_read_str(&path.path, BINPRM_BUF_SIZE, filename);
     if (ret < 0) {
-      set_empty_local_warning(PMW_READ_PATH_STRING);
+      set_empty_local_warning(W_READ_PATH_STRING);
       goto EmitWarning;
     }
 
@@ -205,7 +205,7 @@ static __always_inline void enter_script(struct pt_regs *ctx, void *bprm) {
     if (ret < 0) {
       error_info_t info = {0};
       info.err = ret;
-      set_local_warning(PMW_UPDATE_MAP_ERROR, info);
+      set_local_warning(W_UPDATE_MAP_ERROR, info);
       goto EmitWarning;
     }
   } else {
@@ -219,7 +219,7 @@ static __always_inline void enter_script(struct pt_regs *ctx, void *bprm) {
   if (ret < 0) {
     error_info_t info = {0};
     info.err = ret;
-    set_local_warning(PMW_UPDATE_MAP_ERROR, info);
+    set_local_warning(W_UPDATE_MAP_ERROR, info);
     goto EmitWarning;
   }
 
@@ -228,7 +228,7 @@ static __always_inline void enter_script(struct pt_regs *ctx, void *bprm) {
  EventMismatch:;
   error_info_t info = {0};
   info.stored_pid_tgid = (((u64) event.pid) << 32) | (event.pid);
-  set_local_warning(PMW_PID_TGID_MISMATCH, info);
+  set_local_warning(W_PID_TGID_MISMATCH, info);
 
  EmitWarning:;
   // no room in the stack for a process_message_t; let's use our per-cpu buffer
@@ -323,8 +323,8 @@ static __always_inline u64 push_scripts(struct pt_regs *ctx, buf_t *buffer) {
   goto Done;
 
  WriteError:;
-  if (sz == -PMW_UNEXPECTED) {
-    set_empty_local_warning(PMW_READ_PATH_STRING);
+  if (sz == -W_UNEXPECTED) {
+    set_empty_local_warning(W_READ_PATH_STRING);
   } else {
     set_empty_local_warning(-sz);
   }
@@ -334,7 +334,7 @@ static __always_inline u64 push_scripts(struct pt_regs *ctx, buf_t *buffer) {
  EventMismatch:;
   error_info_t info = {0};
   info.stored_pid_tgid = (((u64) event.pid) << 32) | (event.pid);
-  set_local_warning(PMW_PID_TGID_MISMATCH, info);
+  set_local_warning(W_PID_TGID_MISMATCH, info);
 
  EmitWarning:;
   push_warning(ctx, pm, PM_SCRIPT);

--- a/src/process/unshare.h
+++ b/src/process/unshare.h
@@ -35,8 +35,8 @@ static __always_inline void enter_unshare(struct pt_regs *ctx, int flags)
       process_message_t pm = {0};
       pm.type = PM_WARNING;
       pm.u.warning_info.pid_tgid = pid_tgid;
-      pm.u.warning_info.message_type = PM_UNSHARE;
-      pm.u.warning_info.code = PMW_UPDATE_MAP_ERROR;
+      pm.u.warning_info.message_type.process = PM_UNSHARE;
+      pm.u.warning_info.code = W_UPDATE_MAP_ERROR;
       pm.u.warning_info.info.err = ret;
 
       push_message(ctx, &pm);
@@ -73,7 +73,7 @@ static __always_inline void exit_unshare(struct pt_regs *ctx, pprocess_message_t
  EventMismatch:;
   error_info_t info = {0};
   info.stored_pid_tgid = event.pid_tgid;
-  set_local_warning(PMW_PID_TGID_MISMATCH, info);
+  set_local_warning(W_PID_TGID_MISMATCH, info);
 
  EmitWarning:;
   push_warning(ctx, pm, PM_UNSHARE);

--- a/src/types.h
+++ b/src/types.h
@@ -93,6 +93,7 @@ typedef enum
     W_NULL_FIELD,
     W_INTERP_MISMATCH,
     W_INTERP_SLOT,
+    W_NO_DENTRY,
 } warning_t;
 
 typedef enum

--- a/src/types.h
+++ b/src/types.h
@@ -79,21 +79,21 @@ typedef enum
 
 typedef enum
 {
-    PMW_UNSPEC,
-    PMW_BUFFER_FULL,
-    PMW_TAIL_CALL_MAX,
-    PMW_UPDATE_MAP_ERROR,
-    PMW_PID_TGID_MISMATCH,
-    PMW_UNEXPECTED,
-    PMW_READ_PATH_STRING,
-    PMW_READ_ARGV,
-    PMW_READING_FIELD,
-    PMW_ARGV_INCONSISTENT,
-    PMW_PTR_FIELD_READ,
-    PMW_NULL_FIELD,
-    PMW_INTERP_MISMATCH,
-    PMW_INTERP_SLOT,
-} process_message_warning_t;
+    W_UNSPEC,
+    W_BUFFER_FULL,
+    W_TAIL_CALL_MAX,
+    W_UPDATE_MAP_ERROR,
+    W_PID_TGID_MISMATCH,
+    W_UNEXPECTED,
+    W_READ_PATH_STRING,
+    W_READ_ARGV,
+    W_READING_FIELD,
+    W_ARGV_INCONSISTENT,
+    W_PTR_FIELD_READ,
+    W_NULL_FIELD,
+    W_INTERP_MISMATCH,
+    W_INTERP_SLOT,
+} warning_t;
 
 typedef enum
 {
@@ -110,6 +110,22 @@ typedef enum
     PM_WARNING,
     PM_SCRIPT,
 } process_message_type_t;
+
+typedef enum
+{
+    FM_UNSPEC,
+    FM_CREATE,
+    FM_DELETE,
+    FM_MODIFY,
+    FM_RENAME,
+    FM_WARNING,
+} file_message_type_t;
+
+typedef union
+{
+    process_message_type_t process;
+    file_message_type_t file;
+} message_type_t;
 
 #define COMMON_FIELDS                           \
     u32 pid;                                    \
@@ -216,6 +232,20 @@ typedef struct
 
 typedef struct
 {
+    u32 uid;
+    u32 gid;
+    u32 mode;
+} file_ownership_t;
+
+typedef enum 
+{
+    LINK_NONE,
+    LINK_SYMBOLIC,
+    LINK_HARD,
+} file_link_type_t; 
+
+typedef struct
+{
     u32 child_pid;
     u64 flags;
 } clone_info_t;
@@ -300,6 +330,7 @@ typedef enum
     RET_SYS_EXECVEAT,
     RET_SYS_EXECVE,
     SYS_EXEC_PWD,
+    RET_DO_MKDIRAT,
     HANDLE_PWD,
 } tail_call_slot_t;
 
@@ -317,8 +348,8 @@ typedef union
 
 typedef struct
 {
-    process_message_warning_t code;
-    process_message_type_t message_type;
+    warning_t code;
+    message_type_t message_type;
     u64 pid_tgid;
     error_info_t info;
 } warning_info_t;
@@ -344,6 +375,41 @@ typedef struct
     // not allowed inside union
     char strings[];
 } process_message_t, *pprocess_message_t;
+
+typedef struct
+{
+    u32 pid;
+    u64 mono_ns;
+    u32 buffer_len;
+    file_info_t target;
+    file_ownership_t target_owner;
+    union {
+        struct {
+            file_link_type_t source_link;
+        } create;
+        struct {
+            file_ownership_t before_owner;
+        } modify;
+        struct {
+            file_info_t source;
+            file_info_t overwr;
+            file_ownership_t overwr_owner;
+        } rename;
+    } u;
+} file_action_t;
+
+typedef union
+{
+    file_action_t action;
+    warning_info_t warning;
+} file_message_data_t;
+
+typedef struct
+{
+    file_message_type_t type;
+    file_message_data_t u;
+    char strings[];
+} file_message_t, *pfile_message_t;
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,3,0)
 // clone3 args are not available in sched.h until 5.3, and we build against 4.4


### PR DESCRIPTION
This contains a lot of relatively minor refactoring to make some code written for process events also work for file events. Some more re-organization to move the shared code to a better location is coming.

The file event code is just a starting point, but an event type is in place and it successfully fills out create events when mkdir is used.