### PR TITLE
[LE-727] Hook up path filter state machine

### DIFF
--- a/src/file-events.c
+++ b/src/file-events.c
@@ -100,7 +100,8 @@ static __always_inline int extract_file_info_owner(void *ptr, file_info_t *file_
 typedef struct {
   u64 pid_tgid;
   u64 start_ktime_ns;
-  void *target_dentry;
+  void *target_vfsmount;     // vfsmount of the containing directory
+  void *target_dentry;  // dentry of the new directory
 } incomplete_mkdir_t;
 
 // A map of mkdirs that have started (a kprobe) but are yet to finish
@@ -139,13 +140,14 @@ static __always_inline void enter_mkdir(struct pt_regs *ctx)
     return;
 }
 
-static __always_inline void store_dentry(struct pt_regs *ctx, void *dentry)
+static __always_inline void store_dentry(struct pt_regs *ctx, void *path, void *dentry)
 {
     u64 pid_tgid = bpf_get_current_pid_tgid();
 
     load_event(incomplete_mkdirs, pid_tgid, incomplete_mkdir_t);
     if (event.target_dentry == NULL) {
         event.target_dentry = dentry;
+        event.target_vfsmount = read_field_ptr(path, CRC_PATH_MNT);
         bpf_map_update_elem(&incomplete_mkdirs, &pid_tgid, &event, BPF_ANY);
     }
     return;
@@ -183,7 +185,7 @@ static __always_inline void exit_mkdir(struct pt_regs *ctx, tail_call_slot_t tai
 
     u64 pid_tgid = bpf_get_current_pid_tgid();
     load_event(incomplete_mkdirs, pid_tgid, incomplete_mkdir_t);
-    if (event.target_dentry == NULL) {
+    if (event.target_dentry == NULL || event.target_vfsmount == NULL) {
         set_empty_local_warning(W_NO_DENTRY);
         goto EmitWarning;
     }
@@ -196,17 +198,20 @@ static __always_inline void exit_mkdir(struct pt_regs *ctx, tail_call_slot_t tai
     fm->u.action.buffer_len = sizeof(file_message_t);
     fm->u.action.u.create.source_link = LINK_NONE;
 
-    cached_path->next_dentry = event.target_dentry;
+    init_filtered_cached_path(cached_path, event.target_dentry, event.target_vfsmount);
 
     ResolveName:
     ret = write_path(ctx, cached_path, &cursor, tail_call);
-    cached_path->next_dentry = NULL;
     if (ret < 0) goto EmitWarning;
+    if (cached_path->filter_state <= 0) goto NoEvent; // Didn't match watched path filter
 
-    write_null_char(cursor.buffer, cursor.offset);
+    bpf_probe_read_str(fm->u.action.filter_tag, MAX_TAG, cached_path->filter_tag);
     push_flexible_file_message(ctx, fm, *cursor.offset);
     // My attempts to call bpf_map_delete_elem() so far have caused the verifier to fail it
     // so just rely on the LRU functionality to keep the map from getting too big
+    write_null_char(cursor.buffer, cursor.offset);
+    // lookup tail calls completed; ensure we re-init cached_path next call
+    cached_path->next_dentry = NULL;
     return;
 
     EventMismatch:
@@ -215,9 +220,9 @@ static __always_inline void exit_mkdir(struct pt_regs *ctx, tail_call_slot_t tai
 
     EmitWarning:
     push_file_warning(ctx, fm, FM_CREATE);
-    return;
 
     NoEvent:
+    cached_path->next_dentry = NULL;
     return;
 }
 
@@ -232,9 +237,10 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_mkdirat) {
     enter_mkdir(ctx);
     return 0;
 }
-SEC("kprobe/security_inode_mkdir")
-int BPF_KPROBE(security_inode_mkdir, struct inode *dir, struct dentry *dentry, umode_t mode) {
-    store_dentry(ctx, (void *)dentry);
+
+SEC("kprobe/security_path_mkdir")
+int BPF_KPROBE(security_path_mkdir, const struct path *dir, struct dentry *dentry, umode_t mode) {
+    store_dentry(ctx, (void *)dir, (void *)dentry);
     return 0;
 }
 

--- a/src/process/path.h
+++ b/src/process/path.h
@@ -11,7 +11,21 @@ typedef struct
     void *next_dentry;
     // the virtual fs mount where the path is mounted
     void *vfsmount;
+    // filter state machine state; init to 0 for filtering, -1 for none
+    int filter_state;
+    // filter match tag; filled by filter when a match is found
+    char filter_tag[MAX_TAG];
 } cached_path_t;
+
+// A table containing state transitions for a path parsing filter
+struct bpf_map_def SEC("maps/filter_transitions") filter_transitions = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(filter_key_t),
+    .value_size = sizeof(filter_value_t),
+    .max_entries = 2048,
+    .pinning = 0,
+    .namespace = "",
+};
 
 // A per cpu cache of dentry so we can hold it across tail calls.
 struct bpf_map_def SEC("maps/percpu_path") percpu_path = {
@@ -30,6 +44,21 @@ static __always_inline void init_cached_path(cached_path_t *cached_path, void *p
 
     // cached_path->vfsmount = path->mnt;
     cached_path->vfsmount = read_field_ptr(path, CRC_PATH_MNT);
+
+    // no filtering by default
+    cached_path->filter_state = -1;
+}
+
+static __always_inline void init_filtered_cached_path(cached_path_t *cached_path, void *dentry, void *vfsmount)
+{
+    char empty_tag[MAX_TAG] = {0};
+
+    cached_path->next_dentry = dentry;
+    cached_path->vfsmount = vfsmount;
+    // set the filter machine at the start state;
+    cached_path->filter_state = 0;
+    // clear the filter tag
+    bpf_probe_read(cached_path->filter_tag, MAX_TAG, empty_tag);
 }
 
 // writes '\0' into the buffer; checks and updates the offset
@@ -80,6 +109,10 @@ static __always_inline int write_string(const char *string, buf_t *buffer, u32 *
 }
 
 // writes a d_path into a buffer - tail calling if necessary
+// cached_path needs to be initialized with the dentry + vfsmount of the path to resolve
+// to use path filtering, set cached_path->filter_state to 0 before calling
+// success is indicated by a non-negative return value representing the length of the path
+// a filter match is indicated by a positive cached_path->filter_state upon successful return
 static __always_inline int write_path(struct pt_regs *ctx, cached_path_t *cached_path, cursor_t *buf,
                                       tail_call_slot_t tail_call)
 {
@@ -120,6 +153,18 @@ static __always_inline int write_path(struct pt_regs *ctx, cached_path_t *cached
 
     int ret = 0;
 
+    filter_key_t key = {0};           // the main key storage for filter transition lookups
+    filter_value_t *val = NULL;
+
+    // We trade some stack space for reduced instructions per loop in the filter logic
+    // Because hash maps don't understand null-terminated strings, we have to always
+    // zero-out the full path_segment buffer before copying a string into it.
+    filter_key_t retry_key = {0};     // a separate key for retries, to cut down on strcopy
+    filter_key_t blank_key = {0};     // we copy this blank key over key to zero it easily
+
+    // Init the retry_key's path string, which is always the same
+    retry_key.path_segment[0] = '*';
+
 // Anything we add to this for-loop will be repeated
 // MAX_PATH_SEGMENTS_NOTAIL so be very careful of going over the max
 // instruction limit (4096).
@@ -154,6 +199,25 @@ static __always_inline int write_path(struct pt_regs *ctx, cached_path_t *cached
         if (bpf_probe_read(&offset, sizeof(offset), dentry + name) < 0)
             goto NameError;
 
+        // Path filtering, only if the filter is active
+        if (cached_path->filter_state >= 0) {
+            val = NULL;
+            // We need to reset at least the whole string storage array each time we use the key
+            bpf_probe_read(&key, sizeof(filter_key_t), &blank_key);
+            key.current_state = cached_path->filter_state;
+            if (bpf_probe_read_str(&key.path_segment, MAX_PATH_SEG, offset) > 0) {
+                val = (filter_value_t *)bpf_map_lookup_elem(&filter_transitions, &key);
+            }
+            // One retry with "*" path element if not found
+            if (val == NULL) {
+                // The retry_key always uses the same path segment string so we don't need to reset
+                retry_key.current_state = cached_path->filter_state;
+                val = (filter_value_t *)bpf_map_lookup_elem(&filter_transitions, &retry_key);
+            } 
+            // Terminate the filter lookup if there was no value at either key
+            cached_path->filter_state = val ? val->next_state : -1;
+        }
+
         // NAME_MAX doesn't include null character; so +1 to take it
         // into account. Not all systems enforce NAME_MAX so
         // truncation may happen per path segment. TODO: emit
@@ -174,6 +238,24 @@ static __always_inline int write_path(struct pt_regs *ctx, cached_path_t *cached
     // let's not forget to write the global root (might be a / or the memfd name)
     if (bpf_probe_read(&offset, sizeof(offset), cached_path->next_dentry + name) < 0)
             goto NameError;
+
+    // If the filter is still active, it must match on the first try to succeed
+    if (cached_path->filter_state >= 0) {
+        val = NULL;
+        // We need to reset at least the string array of the key
+        bpf_probe_read(&key, sizeof(filter_key_t), &blank_key);
+        key.current_state = cached_path->filter_state;
+        if (bpf_probe_read_str(&key.path_segment, MAX_PATH_SEG, offset) > 0) {
+            val = (filter_value_t *)bpf_map_lookup_elem(&filter_transitions, &key);
+        }
+        // A successful lookup here is only a match if the tag is not an empty string
+        if (val && val->filter_tag[0]) {
+            cached_path->filter_state = val->next_state;
+            bpf_probe_read_str(cached_path->filter_tag, MAX_TAG, val->filter_tag);
+        } else {
+            cached_path->filter_state = -1;
+        }
+    }
 
     ret = write_string((char *)offset, buf->buffer, buf->offset, NAME_MAX + 1);
     if (ret < 0) goto WriteError;

--- a/src/types.h
+++ b/src/types.h
@@ -377,6 +377,18 @@ typedef struct
     char strings[];
 } process_message_t, *pprocess_message_t;
 
+#define MAX_PATH_SEG 64
+typedef struct {
+    char path_segment[MAX_PATH_SEG];
+    int current_state;
+} filter_key_t;
+
+#define MAX_TAG 8
+typedef struct {
+    int next_state;
+    char filter_tag[MAX_TAG];
+} filter_value_t;
+
 typedef struct
 {
     u32 pid;
@@ -384,6 +396,7 @@ typedef struct
     u32 buffer_len;
     file_info_t target;
     file_ownership_t target_owner;
+    char filter_tag[MAX_TAG];
     union {
         struct {
             file_link_type_t source_link;

--- a/src/types.h
+++ b/src/types.h
@@ -383,10 +383,9 @@ typedef struct {
     int current_state;
 } filter_key_t;
 
-#define MAX_TAG 8
 typedef struct {
     int next_state;
-    char filter_tag[MAX_TAG];
+    int tag;
 } filter_value_t;
 
 typedef struct
@@ -396,7 +395,7 @@ typedef struct
     u32 buffer_len;
     file_info_t target;
     file_ownership_t target_owner;
-    char filter_tag[MAX_TAG];
+    u32 tag;
     union {
         struct {
             file_link_type_t source_link;


### PR DESCRIPTION
This adds the path lookup mechanism using the filter state machine to the path resolution code.

Additionally, filemod path lookups were previously broken due to not including the vfsmount field in the cached_path, which caused lookup to stop at the first mount boundary. This is now fixed, which required hooking a different one of the security functions so we could get a path instead of just a dentry.