### PR TITLE
Fix zero initialization of filter_key_t

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ CFLAGS += \
 	-Wno-gnu-variable-sized-type-not-at-end \
 	-Wno-sometimes-uninitialized \
 	-Wno-tautological-compare \
+        -Wmissing-braces \
 	-fno-stack-protector \
 	-Xclang -disable-llvm-passes \
 	-O2

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ CFLAGS += \
 	-Wno-gnu-variable-sized-type-not-at-end \
 	-Wno-sometimes-uninitialized \
 	-Wno-tautological-compare \
-        -Wmissing-braces \
 	-fno-stack-protector \
 	-Xclang -disable-llvm-passes \
 	-O2

--- a/src/types.h
+++ b/src/types.h
@@ -238,12 +238,12 @@ typedef struct
     u32 mode;
 } file_ownership_t;
 
-typedef enum 
+typedef enum
 {
     LINK_NONE,
     LINK_SYMBOLIC,
     LINK_HARD,
-} file_link_type_t; 
+} file_link_type_t;
 
 typedef struct
 {
@@ -379,8 +379,8 @@ typedef struct
 
 #define MAX_PATH_SEG 64
 typedef struct {
-    char path_segment[MAX_PATH_SEG];
     int current_state;
+    char path_segment[MAX_PATH_SEG];
 } filter_key_t;
 
 typedef struct {


### PR DESCRIPTION
Re-ordered the fields to make our `{0}` initialization work without clang complaining. 