### PR TITLE
making clangd happy

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,15 @@
+---
+If:
+  PathMatch: src/common/bpf_helpers\.h
+Diagnostics:
+  Suppress: -Wunused-variable
+
+---
+CompileFlags:
+  Add: -ferror-limit=0
+
+---
+If:
+  PathMatch: src/file/.*\.h
+CompileFlags:
+  Add: -DUSE_PATH_FILTER=1

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .DS_Store
 **/.DS_Store
 .idea/
+.cache/
+compile_commands.json

--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ check all the sections at the same time.
 eBPF programs can branch (but not jump back!) so make sure to check
 that none of the branches go over the 4096 instructions limit.
 
+# Development with clangd
+
+If clangd is used as the LSP, compile commands can be easily generated with:
+
+```bash
+bear -- make dev
+```
+
+After that `clangd` should be able to pickup the created
+`compile_commands.json`. A config exists in `.clangd` to further tweak
+in case the compile commands are not enough for clangd to have a
+successful build.
+
 # Licensing
 
 Please note, these programs are mostly licensed under GPL, which is

--- a/src/common/bpf_tracing.h
+++ b/src/common/bpf_tracing.h
@@ -518,6 +518,8 @@ static __always_inline typeof(name(0)) ____##name(struct pt_regs *ctx, ##args)
  *  - (parm5) regs[4]
  */
 
+#define u64 unsigned long long
+
 struct _x64_pt_regs
 {
 	u64 r15;

--- a/src/common/path.h
+++ b/src/common/path.h
@@ -21,8 +21,8 @@ typedef struct
     void *next_dentry;
     // the virtual fs mount where the path is mounted
     void *vfsmount;
-    // filter state machine state; init to 0 for filtering, -1 for none
 #if USE_PATH_FILTER
+    // filter state machine state; init to 0 for filtering, -1 for none
     int filter_state;
     // filter match tag; filled by filter when a match is found
     int filter_tag;

--- a/src/file-events.c
+++ b/src/file-events.c
@@ -3,19 +3,10 @@
 // Configure path.h to include filter code
 #define USE_PATH_FILTER 1
 
-#include <linux/kconfig.h>
-#include <linux/version.h>
-#include <linux/fs.h>
+#include <asm/ptrace.h>
+#include <linux/path.h>
 
 #include "common/bpf_helpers.h"
-#include "common/types.h"
-#include "common/offsets.h"
-#include "common/common.h"
-#include "common/helpers.h"
-#include "common/buffer.h"
-#include "common/path.h"
-#include "common/warning.h"
-
 #include "file/mkdir.h"
 
 SEC("kprobe/sys_mkdir")

--- a/src/process/clone.h
+++ b/src/process/clone.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <linux/kconfig.h>
+#include <linux/sched.h>
+#include <asm/ptrace.h>
+
 #include "../common/helpers.h"
 #include "push_message.h"
 

--- a/src/process/exec.h
+++ b/src/process/exec.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <asm/ptrace.h>
+
 #include "../common/bpf_tracing.h"
 #include "../common/buffer.h"
 #include "../common/helpers.h"
 #include "../common/path.h"
-
 #include "push_message.h"
 #include "script.h"
 

--- a/src/process/exit.h
+++ b/src/process/exit.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../common/helpers.h"
 #include "push_message.h"
 
 static __always_inline void push_exit(struct pt_regs *ctx, pprocess_message_t pm,

--- a/src/process/script.h
+++ b/src/process/script.h
@@ -1,5 +1,11 @@
+#pragma once
+
 #include "../common/buffer.h"
+#include "../common/common.h"
+#include "../common/helpers.h"
+#include "../common/path.h"
 #include "../common/types.h"
+#include "./push_message.h"
 
 // 256 is BINPRM_BUF_SIZE starting on kernels 5.1+.
 #define BINPRM_BUF_SIZE 256

--- a/src/process/unshare.h
+++ b/src/process/unshare.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <asm/ptrace.h>
+
 #include "../common/common.h"
 #include "../common/helpers.h"
-
 #include "push_message.h"
 
 typedef struct {


### PR DESCRIPTION
This PR should be a no-op. It is mostly just about adding includes on the right spots so `clangd` is happy and added a clangd config because it wasn't happy about our `bpf_helpers.h` file creating variables that itself was not using (but are used by files that import `bpf_helpers.h`. 