### PR TITLE
Switch mkdir and hardlink to tracepoints

### DIFF
--- a/src/common/offsets.h
+++ b/src/common/offsets.h
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0+
 #pragma once
 
+#include "bpf_tracing.h"
+
 /* CRC64 of "loaded"  */
 const u64 CRC_LOADED = 0xec6642829d632573;
 

--- a/src/common/path.h
+++ b/src/common/path.h
@@ -28,6 +28,10 @@ typedef struct
     int filter_state;
     // filter match tag; filled by filter when a match is found
     int filter_tag;
+    // the next path to process after next_dentry has been *fully* resolved
+    void *next_path;
+    // a cache of the vfsmount before any of the changes done by `write_path`
+    void *original_vfsmount;
 #endif
 } cached_path_t;
 
@@ -75,6 +79,8 @@ static __always_inline void init_filtered_cached_path(cached_path_t *cached_path
     cached_path->filter_state = 0;
     // clear the filter tag
     cached_path->filter_tag = -1;
+    cached_path->next_path = NULL;
+    cached_path->original_vfsmount = vfsmount;
 }
 #endif
 

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -331,7 +331,7 @@ typedef enum
     RET_SYS_EXECVEAT,
     RET_SYS_EXECVE,
     SYS_EXEC_PWD,
-    EXIT_CREATE,
+    EXIT_SYMLINK,
     HANDLE_PWD,
     FILE_PATHS,
 } tail_call_slot_t;

--- a/src/file/create.h
+++ b/src/file/create.h
@@ -131,7 +131,7 @@ static __always_inline void exit_symlink(struct pt_regs *ctx)
  ResolveTarget:
     ret = write_path(ctx, cached_path, &cursor,
                      (tail_call_t){
-                         .slot = EXIT_CREATE,
+                         .slot = EXIT_SYMLINK,
                          .table = &tail_call_table,
                      });
     if (ret < 0) goto EmitWarning;
@@ -157,7 +157,7 @@ static __always_inline void exit_symlink(struct pt_regs *ctx)
     return;
 }
 
-static __always_inline void prepare_create(void *ctx, file_link_type_t link_type)
+static __always_inline void exit_create(void *ctx, file_link_type_t link_type)
 {
     u32 key = 0;
     buf_t *buffer = (buf_t *)bpf_map_lookup_elem(&buffers, &key);

--- a/src/file/create.h
+++ b/src/file/create.h
@@ -178,7 +178,7 @@ static __always_inline void exit_create(void *ctx, file_link_type_t link_type)
     }
 
     // not using read_field_ptr because we expect that `inode` could
-    // be NULL for kernel pseudo filessytems such as cgroupfs. We
+    // be NULL for kernel pseudo filesystems such as cgroupfs. We
     // still want to error if we fail to read the field; we just don't
     // want to error for the field being NULL
     void *inode = NULL;

--- a/src/file/delete.h
+++ b/src/file/delete.h
@@ -83,7 +83,7 @@ static __always_inline void store_deleted_dentry(struct pt_regs *ctx, void *path
     return;
 }
 
-static __always_inline void prepare_delete(void *ctx)
+static __always_inline void exit_delete(void *ctx)
 {
     u32 key = 0;
     buf_t *buffer = (buf_t *)bpf_map_lookup_elem(&buffers, &key);

--- a/src/file/modify.h
+++ b/src/file/modify.h
@@ -83,7 +83,7 @@ static __always_inline void store_modified_dentry(struct pt_regs *ctx, void *pat
     return;
  }
 
-static __always_inline void prepare_modify(void *ctx)
+static __always_inline void exit_modify(void *ctx)
 {
     u32 key = 0;
     buf_t *buffer = (buf_t *)bpf_map_lookup_elem(&buffers, &key);


### PR DESCRIPTION
The goal of this PR is just to make the events that can be a tracepoint be a tracepoint so they can all use the same tail-call for path finding. The only one that's different now is symlink because we want to get the path that the kernel copied out of userspace but that copied path gets deallocated befeore the syscall returns so we gotta hook earlier. We *could* just copy what the user sent instead if we really wanted to use tracepoints for everything but that decision is left for another time. 