### PR TITLE
Updates to renames

### DIFF
--- a/src/file-events.c
+++ b/src/file-events.c
@@ -659,12 +659,7 @@ static __always_inline void filemod_paths(void *ctx)
             goto Done;
 
         NoEvent:
-            fm->type = FM_WARNING;
-            fm->u.warning.pid_tgid = pid_tgid;
-            fm->u.warning.message_type.file = FM_RENAME;
-            fm->u.warning.code = W_UNEXPECTED; // ?
-
-            push_file_message(ctx, fm);
+            // Either the map disappeared or the element aged out so we just ignore it.
             goto Done;
 
         RenameFinished:;

--- a/src/file/create.h
+++ b/src/file/create.h
@@ -23,7 +23,7 @@ struct bpf_map_def SEC("maps/incomplete_creates") incomplete_creates = {
   .type = BPF_MAP_TYPE_LRU_HASH,
   .key_size = sizeof(u64),
   .value_size = sizeof(incomplete_create_t),
-  .max_entries = 256,
+  .max_entries = 512,
   .pinning = 0,
   .namespace = "",
 };

--- a/src/file/delete.h
+++ b/src/file/delete.h
@@ -22,7 +22,7 @@ struct bpf_map_def SEC("maps/incomplete_deletes") incomplete_deletes = {
     .type = BPF_MAP_TYPE_LRU_HASH,
     .key_size = sizeof(u64),
     .value_size = sizeof(incomplete_delete_t),
-    .max_entries = 256,
+    .max_entries = 512,
     .pinning = 0,
     .namespace = "",
 };

--- a/src/file/modify.h
+++ b/src/file/modify.h
@@ -19,7 +19,7 @@ struct bpf_map_def SEC("maps/incomplete_modifies") incomplete_modifies = {
     .type = BPF_MAP_TYPE_LRU_HASH,
     .key_size = sizeof(u64),
     .value_size = sizeof(incomplete_modify_t),
-    .max_entries = 256,
+    .max_entries = 512,
     .pinning = 0,
     .namespace = "",
 };


### PR DESCRIPTION
This PR addresses a few things:
- The section name was incorrect for the `rename_names` map. We don't think this was causing any issues as we still saw the map load fine but just in case. 
- Increase the size of all the file associated maps to `512`. This is in case the `W_UNEXPECTED` warnings were being caused by something aging out. 
- Warn if we failed to update the `rename_names` map. 
- No longer warn if we got a`NULL` back from the `rename_names` map during the `filemod_paths` probe. Because we added warnings if we fail to update, then a failure to read from there on would just mean that either the map was destroyed user-side or the event aged out so it isn't really an error in the program. 