### PR TITLE
Remove W_NO_DENTRY warning from file events

### DIFF
--- a/src/common/types.h
+++ b/src/common/types.h
@@ -93,7 +93,6 @@ typedef enum
     W_NULL_FIELD,
     W_INTERP_MISMATCH,
     W_INTERP_SLOT,
-    W_NO_DENTRY,
 } warning_t;
 
 typedef enum

--- a/src/file/create.h
+++ b/src/file/create.h
@@ -104,10 +104,7 @@ static __always_inline void exit_symlink(struct pt_regs *ctx)
         goto ResolveTarget;
     }
 
-    if (event.target_dentry == NULL || event.target_vfsmount == NULL) {
-        set_empty_local_warning(W_NO_DENTRY);
-        goto EmitWarning;
-    }
+    if (event.target_dentry == NULL || event.target_vfsmount == NULL) goto NoEvent;
 
     // not using read_field_ptr because we expect that `inode` could
     // be NULL in overlayfs as it gets called twice (recursively) and
@@ -172,10 +169,7 @@ static __always_inline void exit_create(void *ctx, file_link_type_t link_type)
     u64 pid_tgid = bpf_get_current_pid_tgid();
     load_event(incomplete_creates, pid_tgid, incomplete_create_t);
 
-    if (event.target_dentry == NULL || event.target_vfsmount == NULL) {
-        set_empty_local_warning(W_NO_DENTRY);
-        goto EmitWarning;
-    }
+    if (event.target_dentry == NULL || event.target_vfsmount == NULL) goto NoEvent;
 
     void *inode = NULL;
     if (link_type == LINK_HARD) {

--- a/src/file/delete.h
+++ b/src/file/delete.h
@@ -102,10 +102,7 @@ static __always_inline void exit_delete(void *ctx)
     u64 pid_tgid = bpf_get_current_pid_tgid();
     load_event(incomplete_deletes, pid_tgid, incomplete_delete_t);
 
-    if (event.target_dentry == NULL || event.target_vfsmount == NULL) {
-        set_empty_local_warning(W_NO_DENTRY);
-        goto EmitWarning;
-    }
+    if (event.target_dentry == NULL || event.target_vfsmount == NULL) goto NoEvent;
 
     fm->type = FM_DELETE;
     fm->u.action.pid = event.pid_tgid >> 32;

--- a/src/file/modify.h
+++ b/src/file/modify.h
@@ -135,10 +135,7 @@ static __always_inline void exit_modify(void *ctx)
     u64 pid_tgid = bpf_get_current_pid_tgid();
     load_event(incomplete_modifies, pid_tgid, incomplete_modify_t);
 
-    if (event.target_dentry == NULL || event.target_vfsmount == NULL) {
-        set_empty_local_warning(W_NO_DENTRY);
-        goto EmitWarning;
-    }
+    if (event.target_dentry == NULL || event.target_vfsmount == NULL) goto NoEvent;
 
     void *inode = read_field_ptr(event.target_dentry, CRC_DENTRY_D_INODE);
     if (inode == NULL) goto EmitWarning;

--- a/src/file/rename.h
+++ b/src/file/rename.h
@@ -147,10 +147,7 @@ static __always_inline void exit_rename(void *ctx)
     u64 pid_tgid = bpf_get_current_pid_tgid();
     load_event(incomplete_renames, pid_tgid, incomplete_rename_t);
 
-    if (event.source_dentry == NULL || event.vfsmount == NULL) {
-        set_empty_local_warning(W_NO_DENTRY);
-        goto EmitWarning;
-    }
+    if (event.source_dentry == NULL || event.vfsmount == NULL) goto NoEvent;
 
     void *d_inode = NULL;
     int ret = read_field(event.source_dentry, CRC_DENTRY_D_INODE, &d_inode, sizeof(d_inode));


### PR DESCRIPTION
We think this warning (`W_NO_DENTRY`) was only possible when either the security probes have not been attached yet or have already been detached by the time an exit_* was hit. There isn't much we can do if the dentry was not available. 