### PR TITLE
Do not emit warnings for dentry being null in more cases

### DIFF
--- a/src/common/helpers.h
+++ b/src/common/helpers.h
@@ -121,16 +121,13 @@ static __always_inline int fill_syscall(syscall_info_t *syscall_info, void *ts, 
 }
 
 // its argument should be a pointer to a file
-static __always_inline int extract_file_info(void *ptr, file_info_t *file_info)
+static __always_inline int file_info_from_ino(void *inode, file_info_t *file_info)
 {
-    void *f_inode = read_field_ptr(ptr, CRC_FILE_F_INODE);
-    if (f_inode == NULL) return -1;
-
-    void *i_sb = read_field_ptr(f_inode, CRC_INODE_I_SB);
+    void *i_sb = read_field_ptr(inode, CRC_INODE_I_SB);
     if (i_sb == NULL) return -1;
 
     // inode
-    if (read_field(f_inode, CRC_INODE_I_INO, &file_info->inode, sizeof(file_info->inode)) < 0)
+    if (read_field(inode, CRC_INODE_I_INO, &file_info->inode, sizeof(file_info->inode)) < 0)
         return -1;
 
     // device major/minor
@@ -141,4 +138,13 @@ static __always_inline int extract_file_info(void *ptr, file_info_t *file_info)
     file_info->devminor = MINOR(i_dev);
 
     return 0;
+}
+
+// its argument should be a pointer to a file
+static __always_inline int file_info_from_file(void *ptr, file_info_t *file_info)
+{
+    void *f_inode = read_field_ptr(ptr, CRC_FILE_F_INODE);
+    if (f_inode == NULL) return -1;
+
+    return file_info_from_ino(f_inode, file_info);
 }

--- a/src/file/create.h
+++ b/src/file/create.h
@@ -114,7 +114,7 @@ static __always_inline void exit_symlink(struct pt_regs *ctx)
     if (ret < 0) goto EmitWarning;
     if (d_inode == NULL) goto NoEvent;
 
-    ret = extract_file_info_owner(d_inode, &fm->u.action.target, &fm->u.action.target_owner);
+    ret = file_and_owner_from_ino(d_inode, &fm->u.action.target, &fm->u.action.target_owner);
     if (ret < 0) goto EmitWarning;
 
     fm->type = FM_CREATE;
@@ -189,7 +189,7 @@ static __always_inline void exit_create(void *ctx, file_link_type_t link_type)
         if (inode == NULL) goto NoEvent;
     }
 
-    int ret = extract_file_info_owner(inode, &fm->u.action.target, &fm->u.action.target_owner);
+    int ret = file_and_owner_from_ino(inode, &fm->u.action.target, &fm->u.action.target_owner);
     if (ret < 0) goto EmitWarning;
 
     fm->type = FM_CREATE;

--- a/src/file/delete.h
+++ b/src/file/delete.h
@@ -63,9 +63,7 @@ static __always_inline void store_deleted_dentry(struct pt_regs *ctx, void *path
     // longer have an inode. Furthermore, some filesystems (e.g., xfs)
     // are more aggressive about inode destruction and clear fields
     // such as file mode early
-    void *d_inode = read_field_ptr(dentry, CRC_DENTRY_D_INODE);
-    if (d_inode == NULL) goto EmitWarning;
-    int ret = extract_file_info_owner(d_inode, &event.target, &event.ownership);
+    int ret = file_from_dentry(dentry, &event.target, &event.ownership);
     if (ret < 0) goto EmitWarning;
 
     bpf_map_update_elem(&incomplete_deletes, &pid_tgid, &event, BPF_ANY);

--- a/src/file/dentry.h
+++ b/src/file/dentry.h
@@ -4,7 +4,7 @@
 #include "../common/helpers.h"
 
 // fill file_owner fields from fields on the passed in inode pointer
-static __always_inline int extract_file_owner(void *d_inode, file_ownership_t *file_owner)
+static __always_inline int file_owner_from_ino(void *d_inode, file_ownership_t *file_owner)
 {
     // uid/gid/mode
     if (read_field(d_inode, CRC_INODE_I_UID, &file_owner->uid, sizeof(file_owner->uid)) < 0)
@@ -19,23 +19,33 @@ static __always_inline int extract_file_owner(void *d_inode, file_ownership_t *f
 
 // fill file_info and file_owner fields from fields on the passed in inode pointer
 // the file_owner pointer may be null if you do not want to get those values
-static __always_inline int extract_file_info_owner(void *d_inode, file_info_t *file_info, file_ownership_t *file_owner)
+static __always_inline int file_and_owner_from_ino(void *d_inode, file_info_t *file_info, file_ownership_t *file_owner)
 {
-    void *i_sb = read_field_ptr(d_inode, CRC_INODE_I_SB);
-    if (i_sb == NULL) return -1;
+    int ret = 0;
+    if (file_info != NULL) ret = file_info_from_ino(d_inode, file_info);
+    if (ret < 0) return ret;
 
-    // inode
-    if (read_field(d_inode, CRC_INODE_I_INO, &file_info->inode, sizeof(file_info->inode)) < 0)
-        return -1;
+    if (file_owner != NULL) ret = file_owner_from_ino(d_inode, file_owner);
+    return ret;
+}
 
-    // device major/minor
-    u32 i_dev = 0;
-    if (read_field(i_sb, CRC_SBLOCK_S_DEV, &i_dev, sizeof(i_dev)) < 0) return -1;
+// proxy for extract_file_info_owner that zeroes out the file + owner info if there is no inode
+static __always_inline int file_from_dentry(void *dentry, file_info_t *file_info, file_ownership_t *file_owner)
+{
+    void *d_inode = NULL;
+    int ret = read_field(dentry, CRC_DENTRY_D_INODE, &d_inode, sizeof(d_inode));
+    if (ret < 0) return ret;
+    if (d_inode != NULL) {
+        ret = file_and_owner_from_ino(d_inode, file_info, file_owner);
+        if (ret < 0) return ret;
+    } else {
+        // if the dentry has no inode it means that it was either
+        // deleted or not set.  zero out the file_info and
+        // file_ownership to indicate that but submit the event anyway
+        // only if it is a filtered path and handle it in userspace
+        if (file_info != NULL) __builtin_memset(file_info, 0, sizeof(*file_info));
+        if (file_owner != NULL) __builtin_memset(file_owner, 0, sizeof(*file_owner));
+    }
 
-    file_info->devmajor = MAJOR(i_dev);
-    file_info->devminor = MINOR(i_dev);
-
-    if (file_owner == NULL) return 0;
-
-    return extract_file_owner(d_inode, file_owner);
+    return 0;
 }

--- a/src/process/exec.h
+++ b/src/process/exec.h
@@ -74,7 +74,7 @@ static __always_inline void exit_exec(struct pt_regs *ctx, process_message_type_
     pm->type = pm_type;
     pm->u.syscall_info.retcode = retcode;
     pm->u.syscall_info.data.exec_info.cgroup_id = cgroup_id;
-    if (extract_file_info(exe, &pm->u.syscall_info.data.exec_info.file_info) < 0) goto EmitWarning;
+    if (file_info_from_file(exe, &pm->u.syscall_info.data.exec_info.file_info) < 0) goto EmitWarning;
 
     // TODO: handle error
     bpf_get_current_comm(&pm->u.syscall_info.data.exec_info.comm, sizeof(pm->u.syscall_info.data.exec_info.comm));

--- a/src/process/script.h
+++ b/src/process/script.h
@@ -117,7 +117,7 @@ static __always_inline void enter_script(struct pt_regs *ctx, void *bprm) {
     goto EmitWarning;
   }
 
-  if (extract_file_info(file, new_interpreter) < 0) goto EmitWarning;
+  if (file_info_from_file(file, new_interpreter) < 0) goto EmitWarning;
   relative_file_info_t rel_interpreter = {0};
   rel_interpreter.pid = pid;
   rel_interpreter.interpreter = *new_interpreter;
@@ -172,7 +172,7 @@ static __always_inline void enter_script(struct pt_regs *ctx, void *bprm) {
 
   event = (script_t){0};
   event.pid = pid;
-  if (extract_file_info(file, &event.file.identity) < 0) goto EmitWarning;
+  if (file_info_from_file(file, &event.file.identity) < 0) goto EmitWarning;
 
   char dev[] = "/dev/fd/";
   char truncated_filename[sizeof(dev)] = {0};


### PR DESCRIPTION
We were seeing errors for FM_MODIFY, but just in case I also removed it from FM_DELETE. We will emit emit warnings in the case of hardlinks without an inode on the source because that code was a little more tangled and we haven't seen any evidence that it could be NULL yet.