### PR TITLE
Update program names so section and names match

### DIFF
--- a/src/cred-events.c
+++ b/src/cred-events.c
@@ -73,7 +73,7 @@ Exit:
 }
 
 SEC("kprobe/sys_setuid")
-int BPF_KPROBE_SYSCALL(kprobe__sys_setuid,
+int BPF_KPROBE_SYSCALL(sys_setuid,
                        u32 ruid)
 {
     DECLARE_CRED_EVENT(SP_SETUID);
@@ -82,14 +82,14 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_setuid,
     return 0;
 }
 
-SEC("kretprobe/sys_setuid")
-int kretprobe__sys_setuid(struct pt_regs *__ctx)
+SEC("kretprobe/ret_sys_setuid")
+int ret_sys_setuid(struct pt_regs *__ctx)
 {
     return dispatch_credentials_event(__ctx);
 }
 
 SEC("kprobe/sys_setgid")
-int BPF_KPROBE_SYSCALL(kprobe__sys_setgid,
+int BPF_KPROBE_SYSCALL(sys_setgid,
                        u32 rgid)
 {
     DECLARE_CRED_EVENT(SP_SETGID);
@@ -98,14 +98,14 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_setgid,
     return 0;
 }
 
-SEC("kretprobe/sys_setgid")
-int kretprobe__sys_setgid(struct pt_regs *__ctx)
+SEC("kretprobe/ret_sys_setgid")
+int ret_sys_setgid(struct pt_regs *__ctx)
 {
     return dispatch_credentials_event(__ctx);
 }
 
 SEC("kprobe/sys_setreuid")
-int BPF_KPROBE_SYSCALL(kprobe__sys_setreuid,
+int BPF_KPROBE_SYSCALL(sys_setreuid,
                        u32 ruid, u32 euid)
 {
     DECLARE_CRED_EVENT(SP_SETREUID);
@@ -115,14 +115,14 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_setreuid,
     return 0;
 }
 
-SEC("kretprobe/sys_setreuid")
-int kretprobe__sys_setreuid(struct pt_regs *__ctx)
+SEC("kretprobe/ret_sys_setreuid")
+int ret_sys_setreuid(struct pt_regs *__ctx)
 {
     return dispatch_credentials_event(__ctx);
 }
 
 SEC("kprobe/sys_setregid")
-int BPF_KPROBE_SYSCALL(kprobe__sys_setregid,
+int BPF_KPROBE_SYSCALL(sys_setregid,
                        u32 rgid, u32 egid)
 {
     DECLARE_CRED_EVENT(SP_SETREGID);
@@ -132,14 +132,14 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_setregid,
     return 0;
 }
 
-SEC("kretprobe/sys_setregid")
-int kretprobe__sys_setregid(struct pt_regs *__ctx)
+SEC("kretprobe/ret_sys_setregid")
+int ret_sys_setregid(struct pt_regs *__ctx)
 {
     return dispatch_credentials_event(__ctx);
 }
 
 SEC("kprobe/sys_setresuid")
-int BPF_KPROBE_SYSCALL(kprobe__sys_setresuid,
+int BPF_KPROBE_SYSCALL(sys_setresuid,
                        u32 ruid, u32 euid, u32 suid)
 {
     DECLARE_CRED_EVENT(SP_SETREUID);
@@ -150,14 +150,14 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_setresuid,
     return 0;
 }
 
-SEC("kretprobe/sys_setresuid")
-int kretprobe__sys_setresuid(struct pt_regs *__ctx)
+SEC("kretprobe/ret_sys_setresuid")
+int ret_sys_setresuid(struct pt_regs *__ctx)
 {
     return dispatch_credentials_event(__ctx);
 }
 
 SEC("kprobe/sys_setresgid")
-int BPF_KPROBE_SYSCALL(kprobe__sys_setresgid,
+int BPF_KPROBE_SYSCALL(sys_setresgid,
                        u32 rgid, u32 egid, u32 sgid)
 {
     DECLARE_CRED_EVENT(SP_SETREGID);
@@ -168,8 +168,8 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_setresgid,
     return 0;
 }
 
-SEC("kretprobe/sys_setresgid")
-int kretprobe__sys_setresgid(struct pt_regs *__ctx)
+SEC("kretprobe/ret_sys_setresgid")
+int ret_sys_setresgid(struct pt_regs *__ctx)
 {
     return dispatch_credentials_event(__ctx);
 }

--- a/src/file-events.c
+++ b/src/file-events.c
@@ -29,9 +29,9 @@ struct syscalls_exit_args
 
 // tail-call-only function to finish and send the symlink message
 SEC("kprobe/exit_symlink")
-int kprobe__exit_symlink(struct pt_regs *ctx)
+int exit_symlink(struct pt_regs *ctx)
 {
-    exit_symlink(ctx);
+    _exit_symlink(ctx);
     return 0;
 }
 
@@ -39,15 +39,15 @@ int kprobe__exit_symlink(struct pt_regs *ctx)
 // mkdir probes
 //
 
-SEC("tracepoint/sys_enter_mkdir")
-int tracepoint__syscalls_sys_enter__mkdir(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_mkdir")
+int sys_enter_mkdir(void *ctx)
 {
     enter_create(ctx);
     return 0;
 }
 
-SEC("tracepoint/sys_enter_mkdirat")
-int tracepoint__syscalls_sys_enter__mkdirat(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_mkdirat")
+int sys_enter_mkdirat(void *ctx)
 {
     enter_create(ctx);
     return 0;
@@ -60,8 +60,8 @@ int BPF_KPROBE(security_path_mkdir, const struct path *dir, struct dentry *dentr
     return 0;
 }
 
-SEC("tracepoint/sys_exit_mkdir")
-int tracepoint__syscalls_sys_exit__mkdir(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_mkdir")
+int sys_exit_mkdir(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -69,8 +69,8 @@ int tracepoint__syscalls_sys_exit__mkdir(struct syscalls_exit_args *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_exit_mkdirat")
-int tracepoint__syscalls_sys_exit__mkdirat(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_mkdirat")
+int sys_exit_mkdirat(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -83,14 +83,14 @@ int tracepoint__syscalls_sys_exit__mkdirat(struct syscalls_exit_args *ctx)
 //
 
 SEC("kprobe/sys_symlink")
-int BPF_KPROBE_SYSCALL(kprobe__sys_symlink)
+int BPF_KPROBE_SYSCALL(sys_symlink)
 {
     enter_create(ctx);
     return 0;
 }
 
 SEC("kprobe/sys_symlinkat")
-int BPF_KPROBE_SYSCALL(kprobe__sys_symlinkat)
+int BPF_KPROBE_SYSCALL(sys_symlinkat)
 {
     enter_create(ctx);
     return 0;
@@ -116,15 +116,15 @@ int BPF_KRETPROBE(ret_vfs_symlink, int retval)
 // hard link probes
 //
 
-SEC("tracepoint/sys_enter_link")
-int tracepoint__syscalls_sys_enter__link(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_link")
+int sys_enter_link(void *ctx)
 {
     enter_create(ctx);
     return 0;
 }
 
-SEC("tracepoint/sys_enter_linkat")
-int tracepoint__syscalls_sys_enter__linkat(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_linkat")
+int sys_enter_linkat(void *ctx)
 {
     enter_create(ctx);
     return 0;
@@ -137,8 +137,8 @@ int BPF_KPROBE(security_path_link, struct dentry *old_dentry, const struct path 
     return 0;
 }
 
-SEC("tracepoint/sys_exit_link")
-int tracepoint__syscalls_sys_exit__link(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_link")
+int sys_exit_link(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -146,8 +146,8 @@ int tracepoint__syscalls_sys_exit__link(struct syscalls_exit_args *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_exit_linkat")
-int tracepoint__syscalls_sys_exit__linkat(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_linkat")
+int sys_exit_linkat(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -159,15 +159,15 @@ int tracepoint__syscalls_sys_exit__linkat(struct syscalls_exit_args *ctx)
 // mknod
 //
 
-SEC("tracepoint/sys_enter_mknod")
-int tracepoint__syscalls_sys_enter__mknod(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_mknod")
+int sys_enter_mknod(void *ctx)
 {
     enter_modify(ctx);
     return 0;
 }
 
-SEC("tracepoint/sys_enter_mknodat")
-int tracepoint__syscalls_sys_enter__mknodat(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_mknodat")
+int sys_enter_mknodat(void *ctx)
 {
     enter_modify(ctx);
     return 0;
@@ -180,8 +180,8 @@ int BPF_KPROBE(security_path_mknod, const struct path *dir, struct dentry *dentr
     return 0;
 }
 
-SEC("tracepoint/sys_exit_mknod")
-int tracepoint__syscalls_sys_exit__mknod(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_mknod")
+int sys_exit_mknod(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -189,8 +189,8 @@ int tracepoint__syscalls_sys_exit__mknod(struct syscalls_exit_args *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_exit_mknodat")
-int tracepoint__syscalls_sys_exit__mknodat(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_mknodat")
+int sys_exit_mknodat(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -202,15 +202,15 @@ int tracepoint__syscalls_sys_exit__mknodat(struct syscalls_exit_args *ctx)
 
 /* START DELETE-LIKE PROBES */
 
-SEC("tracepoint/sys_enter_unlink")
-int tracepoint__syscalls_sys_enter__unlink(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_unlink")
+int sys_enter_unlink(void *ctx)
 {
     enter_delete(ctx);
     return 0;
 }
 
-SEC("tracepoint/sys_exit_unlink")
-int tracepoint__syscalls_sys_exit__unlink(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_unlink")
+int sys_exit_unlink(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -218,15 +218,15 @@ int tracepoint__syscalls_sys_exit__unlink(struct syscalls_exit_args *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_enter_unlinkat")
-int tracepoint__syscalls_sys_enter__unlinkat(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_unlinkat")
+int sys_enter_unlinkat(void *ctx)
 {
     enter_delete(ctx);
     return 0;
 }
 
-SEC("tracepoint/sys_exit_unlinkat")
-int tracepoint__syscalls_sys_exit__unlinkat(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_unlinkat")
+int sys_exit_unlinkat(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -241,8 +241,8 @@ int BPF_KPROBE(security_path_unlink, const struct path *dir, struct dentry *dent
     return 0;
 }
 
-SEC("tracepoint/sys_enter_rmdir")
-int tracepoint__syscalls_sys_enter__rmdir(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_rmdir")
+int sys_enter_rmdir(void *ctx)
 {
     enter_delete(ctx);
     return 0;
@@ -255,8 +255,8 @@ int BPF_KPROBE(security_path_rmdir, const struct path *dir, struct dentry *dentr
     return 0;
 }
 
-SEC("tracepoint/sys_exit_rmdir")
-int tracepoint__syscalls_sys_exit__rmdir(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_rmdir")
+int sys_exit_rmdir(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -268,15 +268,15 @@ int tracepoint__syscalls_sys_exit__rmdir(struct syscalls_exit_args *ctx)
 
 /* START CHMOD-LIKE */
 
-SEC("tracepoint/sys_enter_chmod")
-int tracepoint__syscalls_sys_enter__chmod(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_chmod")
+int sys_enter_chmod(void *ctx)
 {
     enter_modify(ctx);
     return 0;
 }
 
-SEC("tracepoint/sys_exit_chmod")
-int tracepoint__syscalls_sys_exit__chmod(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_chmod")
+int sys_exit_chmod(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -284,15 +284,15 @@ int tracepoint__syscalls_sys_exit__chmod(struct syscalls_exit_args *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_enter_fchmod")
-int tracepoint__syscalls_sys_enter__fchmod(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_fchmod")
+int sys_enter_fchmod(void *ctx)
 {
     enter_modify(ctx);
     return 0;
 }
 
-SEC("tracepoint/sys_exit_fchmod")
-int tracepoint__syscalls_sys_exit__fchmod(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_fchmod")
+int sys_exit_fchmod(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -300,15 +300,15 @@ int tracepoint__syscalls_sys_exit__fchmod(struct syscalls_exit_args *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_enter_fchmodat")
-int tracepoint__syscalls_sys_enter__fchmodat(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_fchmodat")
+int sys_enter_fchmodat(void *ctx)
 {
     enter_modify(ctx);
     return 0;
 }
 
-SEC("tracepoint/sys_exit_fchmodat")
-int tracepoint__syscalls_sys_exit__fchmodat(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_fchmodat")
+int sys_exit_fchmodat(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -327,15 +327,15 @@ int BPF_KPROBE(security_path_chmod, const struct path *path, umode_t mode)
 
 /* START CHOWN-LIKE */
 
-SEC("tracepoint/sys_enter_chown")
-int tracepoint__syscalls_sys_enter__chown(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_chown")
+int sys_enter_chown(void *ctx)
 {
     enter_modify(ctx);
     return 0;
 }
 
-SEC("tracepoint/sys_exit_chown")
-int tracepoint__syscalls_sys_exit__chown(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_chown")
+int sys_exit_chown(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -343,15 +343,15 @@ int tracepoint__syscalls_sys_exit__chown(struct syscalls_exit_args *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_enter_lchown")
-int tracepoint__syscalls_sys_enter__lchown(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_lchown")
+int sys_enter_lchown(void *ctx)
 {
     enter_modify(ctx);
     return 0;
 }
 
-SEC("tracepoint/sys_exit_lchown")
-int tracepoint__syscalls_sys_exit__lchown(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_lchown")
+int sys_exit_lchown(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -359,15 +359,15 @@ int tracepoint__syscalls_sys_exit__lchown(struct syscalls_exit_args *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_enter_fchown")
-int tracepoint__syscalls_sys_enter__fchown(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_fchown")
+int sys_enter_fchown(void *ctx)
 {
     enter_modify(ctx);
     return 0;
 }
 
-SEC("tracepoint/sys_exit_fchown")
-int tracepoint__syscalls_sys_exit__fchown(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_fchown")
+int sys_exit_fchown(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -375,15 +375,15 @@ int tracepoint__syscalls_sys_exit__fchown(struct syscalls_exit_args *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_enter_fchownat")
-int tracepoint__syscalls_sys_enter__fchownat(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_fchownat")
+int sys_enter_fchownat(void *ctx)
 {
     enter_modify(ctx);
     return 0;
 }
 
-SEC("tracepoint/sys_exit_fchownat")
-int tracepoint__syscalls_sys_exit__fchownat(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_fchownat")
+int sys_exit_fchownat(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -402,15 +402,15 @@ int BPF_KPROBE(security_path_chown, const struct path *path, uid_t uid, gid_t gi
 
 /* START RENAME PROBES */
 
-SEC("tracepoint/sys_enter_rename")
-int tracepoint__syscalls_sys_enter__rename(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_rename")
+int sys_enter_rename(void *ctx)
 {
     enter_rename(ctx);
     return 0;
 }
 
-SEC("tracepoint/sys_exit_rename")
-int tracepoint__syscalls_sys_exit__rename(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_rename")
+int sys_exit_rename(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -418,15 +418,15 @@ int tracepoint__syscalls_sys_exit__rename(struct syscalls_exit_args *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_enter_renameat")
-int tracepoint__syscalls_sys_enter__renameat(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_renameat")
+int sys_enter_renameat(void *ctx)
 {
     enter_rename(ctx);
     return 0;
 }
 
-SEC("tracepoint/sys_exit_renameat")
-int tracepoint__syscalls_sys_exit__renameat(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_renameat")
+int sys_exit_renameat(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -434,15 +434,15 @@ int tracepoint__syscalls_sys_exit__renameat(struct syscalls_exit_args *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_enter_renameat2")
-int tracepoint__syscalls_sys_enter__renameat2(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_renameat2")
+int sys_enter_renameat2(void *ctx)
 {
     enter_rename(ctx);
     return 0;
 }
 
-SEC("tracepoint/sys_exit_renameat2")
-int tracepoint__syscalls_sys_exit__renameat2(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_renameat2")
+int sys_exit_renameat2(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -460,8 +460,8 @@ int BPF_KPROBE(security_path_rename, const struct path *old_dir, struct dentry *
 /* END RENAME PROBES */
 /* BEGIN OPEN-LIKE PROBES */
 
-SEC("tracepoint/sys_enter_open")
-int tracepoint__syscalls_sys_enter__open(struct syscalls_enter_open_args *ctx)
+SEC("tracepoint/syscalls/sys_enter_open")
+int sys_enter_open(struct syscalls_enter_open_args *ctx)
 {
     if (is_write_open(ctx->flags)) {
         enter_modify(ctx);
@@ -472,8 +472,8 @@ int tracepoint__syscalls_sys_enter__open(struct syscalls_enter_open_args *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_enter_openat")
-int tracepoint__syscalls_sys_enter__openat(struct syscalls_enter_openat_args *ctx)
+SEC("tracepoint/syscalls/sys_enter_openat")
+int sys_enter_openat(struct syscalls_enter_openat_args *ctx)
 {
     if (is_write_open(ctx->flags)) {
         enter_modify(ctx);
@@ -484,8 +484,8 @@ int tracepoint__syscalls_sys_enter__openat(struct syscalls_enter_openat_args *ct
     return 0;
 }
 
-SEC("tracepoint/sys_enter_openat2")
-int tracepoint__syscalls_sys_enter__openat2(struct syscalls_enter_openat2_args *ctx)
+SEC("tracepoint/syscalls/sys_enter_openat2")
+int sys_enter_openat2(struct syscalls_enter_openat2_args *ctx)
 {
     u64 flags = 0;
     bpf_probe_read(&flags, sizeof(flags), &ctx->how->flags);
@@ -498,8 +498,8 @@ int tracepoint__syscalls_sys_enter__openat2(struct syscalls_enter_openat2_args *
     return 0;
 }
 
-SEC("tracepoint/sys_enter_open_by_handle_at")
-int tracepoint__syscalls_sys_enter_open_by_handle_at(struct syscalls_enter_open_by_handle_at_args *ctx)
+SEC("tracepoint/syscalls/sys_enter_open_by_handle_at")
+int sys_enter_open_by_handle_at(struct syscalls_enter_open_by_handle_at_args *ctx)
 {
     if (is_write_open(ctx->flags)) {
         enter_modify(ctx);
@@ -524,8 +524,8 @@ int BPF_KPROBE(security_file_open, void *file)
     return 0;
 }
 
-SEC("tracepoint/sys_exit_open")
-int tracepoint__syscalls_sys_exit__open(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_open")
+int sys_exit_open(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -533,8 +533,8 @@ int tracepoint__syscalls_sys_exit__open(struct syscalls_exit_args *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_exit_openat")
-int tracepoint__syscalls_sys_exit__openat(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_openat")
+int sys_exit_openat(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -542,8 +542,8 @@ int tracepoint__syscalls_sys_exit__openat(struct syscalls_exit_args *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_exit_openat2")
-int tracepoint__syscalls_sys_exit__openat2(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_openat2")
+int sys_exit_openat2(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -551,8 +551,8 @@ int tracepoint__syscalls_sys_exit__openat2(struct syscalls_exit_args *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_exit_open_by_handle_at")
-int tracepoint__syscalls_sys_exit__open_by_handle_at(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_open_by_handle_at")
+int sys_exit_open_by_handle_at(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -561,8 +561,8 @@ int tracepoint__syscalls_sys_exit__open_by_handle_at(struct syscalls_exit_args *
 }
 
 
-SEC("tracepoint/sys_enter_creat")
-int tracepoint__syscalls_sys_enter_creat(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_creat")
+int sys_enter_creat(void *ctx)
 {
     // creat is equivalent to calling open with O_CREAT | O_WRONLY | O_TRUNC
     // If we see a creat, we should treat it as a write open
@@ -570,8 +570,8 @@ int tracepoint__syscalls_sys_enter_creat(void *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_exit_creat")
-int tracepoint__syscalls_sys_exit__creat(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_creat")
+int sys_exit_creat(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -579,8 +579,8 @@ int tracepoint__syscalls_sys_exit__creat(struct syscalls_exit_args *ctx)
     return 0;
 }
 
-SEC("tracepoint/sys_enter_truncate")
-int tracepoint__syscalls_sys_enter_truncate(void *ctx)
+SEC("tracepoint/syscalls/sys_enter_truncate")
+int sys_enter_truncate(void *ctx)
 {
     enter_modify(ctx);
     return 0;
@@ -593,8 +593,8 @@ int BPF_KPROBE(security_path_truncate, const struct path *path)
     return 0;
 }
 
-SEC("tracepoint/sys_exit_truncate")
-int tracepoint__syscalls_sys_exit__truncate(struct syscalls_exit_args *ctx)
+SEC("tracepoint/syscalls/sys_exit_truncate")
+int sys_exit_truncate(struct syscalls_exit_args *ctx)
 {
     if (ctx->ret < 0)
         return 0;
@@ -604,7 +604,7 @@ int tracepoint__syscalls_sys_exit__truncate(struct syscalls_exit_args *ctx)
 
 /* END OPEN-LIKE PROBES */
 
-static __always_inline void filemod_paths(void *ctx)
+static __always_inline void _filemod_paths(void *ctx)
 {
     u32 key = 0;
     buf_t *buffer = (buf_t *)bpf_map_lookup_elem(&buffers, &key);
@@ -686,9 +686,9 @@ Done:
 }
 
 SEC("tracepoint/filemod_paths")
-int tracepoint__filemod_paths(void *ctx)
+int filemod_paths(void *ctx)
 {
-    filemod_paths(ctx);
+    _filemod_paths(ctx);
     return 0;
 }
 

--- a/src/file/create.h
+++ b/src/file/create.h
@@ -83,7 +83,7 @@ static __always_inline void store_dentry(struct pt_regs *ctx, void *path, void *
     return;
 }
 
-static __always_inline void exit_symlink(struct pt_regs *ctx)
+static __always_inline void _exit_symlink(struct pt_regs *ctx)
 {
     u32 key = 0;
     buf_t *buffer = (buf_t *)bpf_map_lookup_elem(&buffers, &key);

--- a/src/process-events.c
+++ b/src/process-events.c
@@ -18,7 +18,7 @@
 #include "process/unshare.h"
 
 SEC("kprobe/sys_exec_pwd")
-int kprobe__sys_exec_pwd(struct pt_regs *ctx)
+int sys_exec_pwd(struct pt_regs *ctx)
 {
     process_pwd(ctx);
 
@@ -26,7 +26,7 @@ int kprobe__sys_exec_pwd(struct pt_regs *ctx)
 }
 
 SEC("kretprobe/ret_sys_execve")
-int kretprobe__ret_sys_execve(struct pt_regs *ctx)
+int ret_sys_execve(struct pt_regs *ctx)
 {
     exit_exec(ctx, PM_EXECVE, bpf_get_current_cgroup_id(), RET_SYS_EXECVE);
 
@@ -34,7 +34,7 @@ int kretprobe__ret_sys_execve(struct pt_regs *ctx)
 }
 
 SEC("kretprobe/ret_sys_execveat")
-int kretprobe__ret_sys_execveat(struct pt_regs *ctx)
+int ret_sys_execveat(struct pt_regs *ctx)
 {
     exit_exec(ctx, PM_EXECVEAT, bpf_get_current_cgroup_id(), RET_SYS_EXECVEAT);
 
@@ -42,7 +42,7 @@ int kretprobe__ret_sys_execveat(struct pt_regs *ctx)
 }
 
 SEC("kretprobe/ret_sys_execve_pre_4_18")
-int kretprobe__ret_sys_execve_pre_4_18(struct pt_regs *ctx)
+int ret_sys_execve_pre_4_18(struct pt_regs *ctx)
 {
     exit_exec(ctx, PM_EXECVE, 0, RET_SYS_EXECVE);
 
@@ -50,7 +50,7 @@ int kretprobe__ret_sys_execve_pre_4_18(struct pt_regs *ctx)
 }
 
 SEC("kretprobe/ret_sys_execveat_pre_4_18")
-int kretprobe__ret_sys_execveat_pre_4_18(struct pt_regs *ctx)
+int ret_sys_execveat_pre_4_18(struct pt_regs *ctx)
 {
     exit_exec(ctx, PM_EXECVEAT, 0, RET_SYS_EXECVEAT);
 
@@ -59,10 +59,10 @@ int kretprobe__ret_sys_execveat_pre_4_18(struct pt_regs *ctx)
 
 SEC("kprobe/sys_clone_4_8")
 #if defined(__TARGET_ARCH_x86)
-int BPF_KPROBE_SYSCALL(kprobe__sys_clone_4_8, unsigned long flags, void __user *stack,
+int BPF_KPROBE_SYSCALL(sys_clone_4_8, unsigned long flags, void __user *stack,
                        int __user *parent_tid, int __user *child_tid, unsigned long tls)
 #elif defined(__TARGET_ARCH_arm64)
-int BPF_KPROBE_SYSCALL(kprobe__sys_clone_4_8, unsigned long flags, void __user *stack,
+int BPF_KPROBE_SYSCALL(sys_clone_4_8, unsigned long flags, void __user *stack,
                        int __user *parent_tid, unsigned long tls, int __user *child_tid)
 #endif
 {
@@ -72,7 +72,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_clone_4_8, unsigned long flags, void __user *
 }
 
 SEC("kprobe/sys_clone3")
-int BPF_KPROBE_SYSCALL(kprobe__sys_clone3, struct clone_args __user *uargs, size_t size)
+int BPF_KPROBE_SYSCALL(sys_clone3, struct clone_args __user *uargs, size_t size)
 {
     u64 flags = 0;
     bpf_probe_read(&flags, sizeof(u64), &uargs->flags);
@@ -83,7 +83,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_clone3, struct clone_args __user *uargs, size
 }
 
 SEC("kretprobe/ret_sys_clone3")
-int kretprobe__ret_sys_clone3(struct pt_regs *ctx)
+int ret_sys_clone3(struct pt_regs *ctx)
 {
     process_message_t sev = {0};
     exit_clone(ctx, &sev, PM_CLONE3);
@@ -96,7 +96,7 @@ int kretprobe__ret_sys_clone3(struct pt_regs *ctx)
 // tracing fork, clone, etc. It returns early if the task is not a
 // main thread (pid != tid).
 SEC("kprobe/read_pid_task_struct")
-int kprobe__read_pid_task_struct(struct pt_regs *ctx)
+int read_pid_task_struct(struct pt_regs *ctx)
 {
     // get passed in task_struct
     void *ts = (void *)PT_REGS_PARM1(ctx);
@@ -106,7 +106,7 @@ int kprobe__read_pid_task_struct(struct pt_regs *ctx)
 }
 
 SEC("kprobe/sys_fork_4_8")
-int BPF_KPROBE_SYSCALL(kprobe__sys_fork_4_8)
+int BPF_KPROBE_SYSCALL(sys_fork_4_8)
 {
     enter_clone(ctx, PM_FORK, SIGCHLD);
 
@@ -114,7 +114,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_fork_4_8)
 }
 
 SEC("kprobe/sys_vfork_4_8")
-int BPF_KPROBE_SYSCALL(kprobe__sys_vfork_4_8)
+int BPF_KPROBE_SYSCALL(sys_vfork_4_8)
 {
     enter_clone(ctx, PM_VFORK, CLONE_VFORK | CLONE_VM | SIGCHLD);
 
@@ -122,7 +122,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_vfork_4_8)
 }
 
 SEC("kretprobe/ret_sys_clone")
-int kretprobe__ret_sys_clone(struct pt_regs *ctx)
+int ret_sys_clone(struct pt_regs *ctx)
 {
     process_message_t pm = {0};
     exit_clone(ctx, &pm, PM_CLONE);
@@ -130,7 +130,7 @@ int kretprobe__ret_sys_clone(struct pt_regs *ctx)
 }
 
 SEC("kretprobe/ret_sys_fork")
-int kretprobe__ret_sys_fork(struct pt_regs *ctx)
+int ret_sys_fork(struct pt_regs *ctx)
 {
     process_message_t pm = {0};
     exit_clone(ctx, &pm, PM_FORK);
@@ -138,7 +138,7 @@ int kretprobe__ret_sys_fork(struct pt_regs *ctx)
 }
 
 SEC("kretprobe/ret_sys_vfork")
-int kretprobe__ret_sys_vfork(struct pt_regs *ctx)
+int ret_sys_vfork(struct pt_regs *ctx)
 {
     process_message_t pm = {0};
     exit_clone(ctx, &pm, PM_VFORK);
@@ -146,7 +146,7 @@ int kretprobe__ret_sys_vfork(struct pt_regs *ctx)
 }
 
 SEC("kprobe/sys_unshare_4_8")
-int BPF_KPROBE_SYSCALL(kprobe__sys_unshare_4_8, int flags)
+int BPF_KPROBE_SYSCALL(sys_unshare_4_8, int flags)
 {
     enter_unshare(ctx, flags);
 
@@ -154,7 +154,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_unshare_4_8, int flags)
 }
 
 SEC("kretprobe/ret_sys_unshare")
-int kretprobe__ret_sys_unshare(struct pt_regs *ctx)
+int ret_sys_unshare(struct pt_regs *ctx)
 {
     process_message_t pm = {0};
     exit_unshare(ctx, &pm);
@@ -162,7 +162,7 @@ int kretprobe__ret_sys_unshare(struct pt_regs *ctx)
 }
 
 SEC("kprobe/sys_exit")
-int BPF_KPROBE_SYSCALL(kprobe__sys_exit, int status)
+int BPF_KPROBE_SYSCALL(sys_exit, int status)
 {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
@@ -179,7 +179,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_exit, int status)
 }
 
 SEC("kprobe/sys_exit_group")
-int BPF_KPROBE_SYSCALL(kprobe__sys_exit_group, int status)
+int BPF_KPROBE_SYSCALL(sys_exit_group, int status)
 {
     process_message_t pm = {0};
     push_exit(ctx, &pm, PM_EXITGROUP, bpf_get_current_pid_tgid() >> 32);
@@ -188,7 +188,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_exit_group, int status)
 }
 
 SEC("kprobe/sys_execveat")
-int BPF_KPROBE_SYSCALL(kprobe__sys_execveat,
+int BPF_KPROBE_SYSCALL(sys_execveat,
                        int fd, const char __user *filename,
                        const char __user *const __user *argv,
                        const char __user *const __user *envp,
@@ -202,7 +202,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_execveat,
 }
 
 SEC("kprobe/sys_execve")
-int BPF_KPROBE_SYSCALL(kprobe__sys_execve,
+int BPF_KPROBE_SYSCALL(sys_execve,
                        const char __user *filename,
                        const char __user *const __user *argv,
                        const char __user *const __user *envp)
@@ -215,7 +215,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_execve,
 }
 
 SEC("kprobe/load_script")
-int kprobe__load_script(struct pt_regs *ctx)
+int load_script(struct pt_regs *ctx)
 {
     void *bprm = (void *)PT_REGS_PARM1(ctx);
     enter_script(ctx, bprm);

--- a/src/wpm-events.c
+++ b/src/wpm-events.c
@@ -103,7 +103,7 @@ int uprobe__read_return_string(struct pt_regs *ctx)
 }
 
 SEC("kprobe/sys_ptrace_write")
-int BPF_KPROBE_SYSCALL(kprobe__sys_ptrace_write,
+int BPF_KPROBE_SYSCALL(sys_ptrace_write,
                        u32 request, u32 target_pid, void *addr)
 {
     syscall_pattern_type_t syscall_pattern = ptrace_syscall_pattern(request);
@@ -130,7 +130,7 @@ Exit:
 }
 
 SEC("kprobe/sys_ptrace")
-int BPF_KPROBE_SYSCALL(kprobe__sys_ptrace,
+int BPF_KPROBE_SYSCALL(sys_ptrace,
                        u32 request, u32 target_pid)
 {
     syscall_pattern_type_t syscall_pattern = ptrace_syscall_pattern(request);
@@ -156,7 +156,7 @@ Exit:
 }
 
 SEC("kprobe/sys_process_vm_writev_5_5")
-int BPF_KPROBE_SYSCALL(kprobe__sys_process_vm_writev_5_5,
+int BPF_KPROBE_SYSCALL(sys_process_vm_writev_5_5,
                        u32 target_pid, piovec_t liov, u32 liovcnt, piovec_t riov, u32 riovcnt)
 {
     DECLARE_EVENT(write_process_memory_event_t, SP_PROCESS_VM_WRITEV);
@@ -180,7 +180,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_process_vm_writev_5_5,
 }
 
 SEC("kprobe/sys_process_vm_writev")
-int BPF_KPROBE_SYSCALL(kprobe__sys_process_vm_writev,
+int BPF_KPROBE_SYSCALL(sys_process_vm_writev,
                        u32 target_pid)
 {
     DECLARE_EVENT(write_process_memory_event_t, SP_PROCESS_VM_WRITEV);
@@ -196,7 +196,7 @@ int BPF_KPROBE_SYSCALL(kprobe__sys_process_vm_writev,
 }
 
 SEC("kprobe/sys_mprotect")
-int BPF_KPROBE_SYSCALL(kprobe__sys_mprotect,
+int BPF_KPROBE_SYSCALL(sys_mprotect,
                        void *addr, u64 len, u32 prot)
 {
     DECLARE_EVENT(change_memory_permission_event_t, SP_MPROTECT);


### PR DESCRIPTION
It seems like the standard now for eBPF loaders is to use the function name rather than the section name (aya for example made the breaking change to use function names recently). Additionally, we didn't have the `/syscalls/` portion in the section name of tracepoints which is not standard (but we had to do to make it runnable with aya which has since fixed it since they use the function name now). 

This PR fixes these issues thus making our programs more standard. 