### PR TITLE
File events minor bugs

### DIFF
--- a/src/file-events.c
+++ b/src/file-events.c
@@ -13,7 +13,6 @@
 #include "file/delete.h"
 #include "file/maps.h"
 #include "file/modify.h"
-#include "file/open.h"
 #include "file/rename.h"
 
 /* START CREATE-LIKE PROBES */
@@ -459,9 +458,7 @@ int BPF_KPROBE(security_path_rename, const struct path *old_dir, struct dentry *
 SEC("tracepoint/syscalls/sys_enter_open")
 int sys_enter_open(struct syscalls_enter_open_args *ctx)
 {
-    if (is_write_open(ctx->flags)) {
-        enter_modify(ctx);
-    }
+    maybe_enter_modify(ctx, ctx->flags);
 
     return 0;
 }
@@ -469,9 +466,7 @@ int sys_enter_open(struct syscalls_enter_open_args *ctx)
 SEC("tracepoint/syscalls/sys_enter_openat")
 int sys_enter_openat(struct syscalls_enter_openat_args *ctx)
 {
-    if (is_write_open(ctx->flags)) {
-        enter_modify(ctx);
-    }
+    maybe_enter_modify(ctx, ctx->flags);
 
     return 0;
 }
@@ -481,9 +476,7 @@ int sys_enter_openat2(struct syscalls_enter_openat2_args *ctx)
 {
     u64 flags = 0;
     bpf_probe_read_user(&flags, sizeof(flags), &ctx->how->flags);
-    if (is_write_open(flags)) {
-        enter_modify(ctx);
-    }
+    maybe_enter_modify(ctx, flags);
 
     return 0;
 }
@@ -491,9 +484,7 @@ int sys_enter_openat2(struct syscalls_enter_openat2_args *ctx)
 SEC("tracepoint/syscalls/sys_enter_open_by_handle_at")
 int sys_enter_open_by_handle_at(struct syscalls_enter_open_by_handle_at_args *ctx)
 {
-    if (is_write_open(ctx->flags)) {
-        enter_modify(ctx);
-    }
+    maybe_enter_modify(ctx, ctx->flags);
 
     return 0;
 }

--- a/src/file/modify.h
+++ b/src/file/modify.h
@@ -60,6 +60,7 @@ static __always_inline file_message_t* exit_modify(void *ctx, u64 pid_tgid, inco
     fm = (file_message_t *)buffer;
     if (event->modify.is_created) {
         fm->type = FM_CREATE;
+        fm->u.action.u.create.source_link = LINK_NONE;
     } else {
         fm->type = FM_MODIFY;
         fm->u.action.u.modify.before_owner = event->modify.before_owner;

--- a/src/file/modify.h
+++ b/src/file/modify.h
@@ -6,11 +6,24 @@
 #include "common/types.h"
 #include "file/dentry.h"
 #include "file/maps.h"
+#include "file/open.h"
 #include "push_file_message.h"
 
 static __always_inline void enter_modify(void *ctx)
 {
     enter_file_message(ctx, FM_MODIFY);
+}
+
+static __always_inline void maybe_enter_modify(void *ctx, long flags)
+{
+    if (is_write_open(flags)) {
+        enter_modify(ctx);
+    } else {
+        // if any previous message forgot to POP this pid_tgid; then we need to delete it as it is
+        // no longer valid. Forgetting to delete here may trigger a warning from kind mismatch
+        u64 pid_tgid = bpf_get_current_pid_tgid();
+        bpf_map_delete_elem(&incomplete_file_messages, &pid_tgid);
+    }
 }
 
 // This method is called when a file is created by passing through security_path_mknod. It stores the dentry


### PR DESCRIPTION
1. Make sure to set `LINK_NONE` for file creations caused by an open syscall. Because we don't clear the per-cpu buffer memory, sometimes (I noticed this during high file events load) this data would be set to something else, namely `LINK_HARD`. 

2. Prevent mismatch errors if we forget to pop and the same pid/tgid then opens a file for reading. I manually deleted our popping code and check what happened and saw some errors caused by this. 

3. Use `BPF_NOEXIST` when inserting elements into the `incomplete_file_messages` map. This makes it more likely that userspace will get the proper warning caused by a bug where we forget to pop events. If we don't do this and there is a bug where we forget to pop then we will process an event correctly but userspace might then detect that we are still processing events so the map is OK even though it might be full but a single PID keeps emitting events because the PID is already in there (i.e., PID 1 touching up systemd periodically)