### PR TITLE
Support filemod events for systems without `CONFIG_SECURITY_PATH`

### DIFF
--- a/src/common/definitions.h
+++ b/src/common/definitions.h
@@ -212,3 +212,7 @@
 #ifndef MINOR
 #define MINOR(dev) ((unsigned int)((dev)&MINORMASK))
 #endif
+
+#ifndef KERNEL_VERSION
+#define KERNEL_VERSION(a, b, c) (((a) << 16) + ((b) << 8) + ((c) > 255 ? 255 : (c)))
+#endif

--- a/src/common/offsets.h
+++ b/src/common/offsets.h
@@ -152,3 +152,6 @@ const u64 CRC_TASK_STRUCT_AUDIT = 0x67da4ab26d333059;
 
 /* audit_task_info->loginuid */
 const u64 CRC_AUDIT_TASK_INFO_LOGINUID = 0xe6dd107ea26da1a0;
+
+/* LINUX_KERNEL_VERSION */
+const u64 CRC_LINUX_KERNEL_VERSION = 0xbd0860b98f6d2ade;

--- a/src/file-events.c
+++ b/src/file-events.c
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0+
 
 // Configure path.h to include filter code
-#include "common/common.h"
-#include "common/definitions.h"
 #define USE_PATH_FILTER 1
 // Configure path.h with maximum segments we can read from a d_path before doing a tail call
 #define MAX_PATH_SEGMENTS_NOTAIL 25
@@ -10,6 +8,8 @@
 #include "vmlinux.h"
 
 #include "common/bpf_helpers.h"
+#include "common/common.h"
+#include "common/definitions.h"
 #include "common/offsets.h"
 #include "common/types.h"
 #include "file/create.h"
@@ -210,7 +210,14 @@ int sys_enter_mknodat(void *ctx)
 SEC("kprobe/security_path_mknod")
 int BPF_KPROBE(security_path_mknod, const struct path *dir, struct dentry *dentry, umode_t mode, unsigned int dev)
 {
-    store_open_create_dentry(ctx, (void *)dir, (void *)dentry);
+    store_open_create_path_dentry(ctx, (void *)dir, (void *)dentry);
+    return 0;
+}
+
+SEC("kprobe/security_inode_create")
+int BPF_KPROBE(security_inode_create, struct inode *dir, struct dentry *dentry, umode_t mode)
+{
+    store_open_create_dentry(ctx, dentry);
     return 0;
 }
 

--- a/src/file-events.c
+++ b/src/file-events.c
@@ -508,7 +508,14 @@ int sys_exit_renameat2(struct syscalls_exit_args *ctx)
 SEC("kprobe/security_path_rename")
 int BPF_KPROBE(security_path_rename, const struct path *old_dir, struct dentry *old_dentry, const struct path *new_dir, struct dentry *new_dentry)
 {
-    store_renamed_dentries(ctx, (void *)old_dir, old_dentry, (void *)new_dir, new_dentry);
+    store_renamed_path_dentries(ctx, (void *)old_dir, old_dentry, (void *)new_dir, new_dentry);
+    return 0;
+}
+
+SEC("kprobe/security_inode_rename")
+int BPF_KPROBE(security_inode_rename, struct inode *old_dir, struct dentry *old_dentry, struct inode *new_dir, struct dentry *new_dentry)
+{
+    store_renamed_dentries(ctx, old_dentry, new_dentry);
     return 0;
 }
 

--- a/src/file-events.c
+++ b/src/file-events.c
@@ -265,7 +265,14 @@ int sys_exit_unlinkat(struct syscalls_exit_args *ctx)
 SEC("kprobe/security_path_unlink")
 int BPF_KPROBE(security_path_unlink, const struct path *dir, struct dentry *dentry)
 {
-    store_deleted_dentry(ctx, (void *)dir, dentry);
+    store_deleted_path_dentry(ctx, (void *)dir, dentry);
+    return 0;
+}
+
+SEC("kprobe/security_inode_unlink")
+int BPF_KPROBE(security_inode_unlink, struct inode *dir, struct dentry *dentry)
+{
+    store_deleted_dentry(ctx, dentry);
     return 0;
 }
 
@@ -279,7 +286,14 @@ int sys_enter_rmdir(void *ctx)
 SEC("kprobe/security_path_rmdir")
 int BPF_KPROBE(security_path_rmdir, const struct path *dir, struct dentry *dentry)
 {
-    store_deleted_dentry(ctx, (void *)dir, dentry);
+    store_deleted_path_dentry(ctx, (void *)dir, dentry);
+    return 0;
+}
+
+SEC("kprobe/security_inode_rmdir")
+int BPF_KPROBE(security_inode_rmdir, struct inode *dir, struct dentry *dentry)
+{
+    store_deleted_dentry(ctx, dentry);
     return 0;
 }
 

--- a/src/file-events.c
+++ b/src/file-events.c
@@ -55,6 +55,13 @@ int BPF_KPROBE(security_path_mkdir, const struct path *dir, struct dentry *dentr
     return 0;
 }
 
+SEC("kprobe/security_inode_mkdir")
+int BPF_KPROBE(security_inode_mkdir, const struct inode *dir, struct dentry *dentry, umode_t mode)
+{
+    store_create_dentry(ctx, dentry, NULL);
+    return 0;
+}
+
 SEC("tracepoint/syscalls/sys_exit_mkdir")
 int sys_exit_mkdir(struct syscalls_exit_args *ctx)
 {
@@ -154,6 +161,13 @@ SEC("kprobe/security_path_link")
 int BPF_KPROBE(security_path_link, struct dentry *old_dentry, const struct path *new_dir, struct dentry *new_dentry)
 {
     store_create_path_dentry(ctx, (void *)new_dir, (void *)new_dentry, (void *)old_dentry);
+    return 0;
+}
+
+SEC("kprobe/security_inode_link")
+int BPF_KPROBE(security_inode_link, struct dentry *old_dentry, struct inode *dir, struct dentry *new_dentry)
+{
+    store_create_dentry(ctx, new_dentry, old_dentry);
     return 0;
 }
 

--- a/src/file/create.h
+++ b/src/file/create.h
@@ -15,13 +15,20 @@ static __always_inline void enter_create(void *ctx)
 }
 
 // The source parameter should be NULL if there is no source, a dentry for hard links, or a char * for symlink
-static __always_inline void store_dentry(struct pt_regs *ctx, void *path, void *dentry, void *source)
+static __always_inline incomplete_file_message_t* store_create_dentry(struct pt_regs *ctx, void *dentry, void *source)
 {
-    incomplete_file_message_t* event = set_file_path(ctx, FM_CREATE, path, dentry);
-    if (event == NULL) return;
+    incomplete_file_message_t* event = set_file_dentry(ctx, FM_CREATE, dentry);
+    if (event == NULL) return NULL;
 
     event->create.source = source;
-    return;
+    return event;
+}
+
+// The source parameter should be NULL if there is no source, a dentry for hard links, or a char * for symlink
+static __always_inline void store_create_path_dentry(struct pt_regs *ctx, void *path, void *dentry, void *source)
+{
+    incomplete_file_message_t* event = store_create_dentry(ctx, dentry, source);
+    set_path_mnt(ctx, event, path);
 }
 
 static __always_inline void _exit_symlink(struct pt_regs *ctx, u64 pid_tgid, incomplete_file_message_t *event)

--- a/src/file/maps.h
+++ b/src/file/maps.h
@@ -152,23 +152,6 @@ static __always_inline void set_current_file_mnt(struct pt_regs *ctx, void *file
     return;
 }
 
-static __always_inline incomplete_file_message_t* set_file_path(struct pt_regs *ctx, file_message_type_t kind,
-                                                         void *path, void *dentry)
-{
-    incomplete_file_message_t* event = set_file_dentry(ctx, kind, dentry);
-    if (event == NULL) return NULL;
-
-    event->vfsmount = read_field_ptr(path, CRC_PATH_MNT);
-    if (event->vfsmount == NULL) goto EmitWarning;
-
-    return event;
-
- EmitWarning:;
-    file_message_t fm = {0};
-    push_file_warning(ctx, &fm, event->kind);
-    return NULL;
-}
-
 // Handles the end states of a given message
 // If null, do nothing
 // If warning, emit the warning

--- a/src/file/modify.h
+++ b/src/file/modify.h
@@ -38,25 +38,31 @@ static __always_inline void store_open_create_dentry(struct pt_regs *ctx, void *
     event->modify.is_created = true;
 
     return;
- }
+}
 
-static __always_inline void store_modified_dentry(struct pt_regs *ctx, void *path)
+static __always_inline incomplete_file_message_t* store_modified_dentry(struct pt_regs *ctx, void *dentry)
 {
-    void *dentry = read_field_ptr(path, CRC_PATH_DENTRY);
-    incomplete_file_message_t* event = set_file_path(ctx, FM_MODIFY, path, dentry);
-    if (event == NULL) return;
+    incomplete_file_message_t* event = set_file_dentry(ctx, FM_MODIFY, dentry);
+    if (event == NULL) return NULL;
 
     if (file_from_dentry(event->target_dentry, NULL, &event->modify.before_owner) < 0) {
         goto EmitWarning;
     }
 
-    return;
+    return event;
 
  EmitWarning:;
     file_message_t fm = {0};
     push_file_warning(ctx, &fm, FM_MODIFY);
-    return;
- }
+    return NULL;
+}
+
+static __always_inline void store_modified_path_dentry(struct pt_regs *ctx, void *path)
+{
+    void *dentry = read_field_ptr(path, CRC_PATH_DENTRY);
+    void *event = store_modified_dentry(ctx, dentry);
+    set_path_mnt(ctx, event, path);
+}
 
 static __always_inline file_message_t* exit_modify(void *ctx, u64 pid_tgid, incomplete_file_message_t *event)
 {


### PR DESCRIPTION
In systems that do not have `CONFIG_SECURITY_PATH` enabled we cannot hook into any of the `security_path_XXX` as they are static inline functions (they are also no-ops so they'll probably get compiled out). To be able to support emitting file events on such systems we need to hook into their `security_inode_XXX` counterparts. 

In summary:

* `security_path_mkdir` -> `security_inode_mkdir`
* `security_path_symlink` -> `security_inode_symlink`
* `security_path_link` -> `security_inode_link`
* `security_path_mknod` -> `security_inode_create`
* `security_path_unlink` -> `security_inode_unlink`
* `security_path_rmdir` -> `security_inode_rmdir`
* `security_path_rename` -> `security_inode_rename`
* `security_path_chown`,  `security_path_chmod`, `security_path_truncate` -> `security_inode_setattr`

These were all fairly straightforward changes, except for `security_inode_setattr` as that function had a signature change in kernel 6.0 where the `dentry` argument moved from the first to second spot. That's *pretty* annoying but I still think these functions have the most likelihood of being stable over any other possible hook points, we just gotta be aware that they obviously aren't as stable as syscall hooks. To get around the issue for `security_inode_setattr`, I added a new possible offset key, that isn't really an offset but is instead the currently running kernel version. If we were doing CO-RE this could be done using `__kconfig` extern variables but alas we aren't there yet. I am conflicted in overloading what this map is there for by making it now just "a map of constant integers" whereas it's starting intention is "a map of offsets". Since I *do* want us to to eventually move to CO-RE I decided this in-between papercut is fine, but I may live to regret that later TBD. With the knowledge of our kernel version code we can then configure whether to read the first or second argument of the kprobe. 

The downside of the `inode` hooks, however, is that they do not have any mount information so we need to retrieve them from elsewhere (paths have a pointer to their vfs mount, inodes don't know where they are mounted). To be able to get the mount I have also added the following hooks:

* `mnt_want_write_file_path`: Prior to kernel 4.18 `fchown` calls for this to ask for write permissions on a mount
* `mnt_want_write_file`: After kernel 4.18 `fchown` calls for this to ask for write permissions on a mount
* `mnt_want_write`: All other syscalls on all released mainline kernels versions we care about (v4.14-v6.7) call for this to ask for write permissions on a mount

These three hooks will look for a file event of *any kind* for the current pid/tgid in our map and set the mount if not yet set. 

The goal is that by the time the exit tracepoints are hit, both the mnt and inode hooks would have been triggered so that the exit hook has all the information needed to emit the event. 