### PR TITLE
Make `clone`, `fork`, and `execve(at)` syscall be k(ret)probes again

### DIFF
--- a/src/process/clone.h
+++ b/src/process/clone.h
@@ -55,12 +55,11 @@ static __always_inline void enter_clone(void *ctx, process_message_type_t pm_typ
 }
 
 // handles the kretprobe of clone-like syscalls (fork, vfork, clone, clone3)
-static __always_inline void exit_clone(struct syscalls_exit_args *ctx, pprocess_message_t pm, process_message_type_t pm_type)
+static __always_inline void exit_clone(void *ctx, pprocess_message_t pm, process_message_type_t pm_type, int retcode)
 {
   u64 pid_tgid = bpf_get_current_pid_tgid();
   load_event(incomplete_clones, pid_tgid, incomplete_clone_t);
 
-  int retcode = ctx->ret;
   if (retcode < 0)
     goto Done;
 


### PR DESCRIPTION
RHEL 7, Centos 7, and Oracle 7 do not expose these as tracepoints and they are still not EOL

RHEL and Centos 7 go into EOL on June of next year so we can revisit the decision of supporting them then. Oracle 7 doesn't go into EOL for another 2+ years but 🤷🏽 . 

Alternatively in the future we can add re-add the tracepoints and have these kprobes as backups or something. 