### PR TITLE
Add a `probe_id` to warning messages to easier debug issues

### DIFF
--- a/src/common/types.h
+++ b/src/common/types.h
@@ -32,6 +32,34 @@ struct in6_addr {
 #define MAX_ADDRESSES 16
 #define TASK_COMM_LEN 16
 
+typedef enum {
+  // there are less than 65535 syscalls so this is a safe value
+  PF_UNSPEC = 0xFFFF,
+  PF_EXIT_SYMLINK,
+  PF_SECURITY_FILE_OPEN,
+  PF_SECURITY_INODE_CREATE,
+  PF_SECURITY_INODE_LINK,
+  PF_SECURITY_INODE_MKDIR,
+  PF_SECURITY_INODE_RENAME,
+  PF_SECURITY_INODE_RMDIR,
+  PF_SECURITY_INODE_SETATTR,
+  PF_SECURITY_INODE_SYMLINK,
+  PF_SECURITY_INODE_UNLINK,
+  PF_SECURITY_PATH_CHMOD,
+  PF_SECURITY_PATH_CHOWN,
+  PF_SECURITY_PATH_LINK,
+  PF_SECURITY_PATH_MKDIR,
+  PF_SECURITY_PATH_MKNOD,
+  PF_SECURITY_PATH_RENAME,
+  PF_SECURITY_PATH_RMDIR,
+  PF_SECURITY_PATH_SYMLINK,
+  PF_SECURITY_PATH_TRUNCATE,
+  PF_SECURITY_PATH_UNLINK,
+  PF_MNT_WANT_WRITE_FILE,
+  PF_MNT_WANT_WRITE_FILE_PATH,
+  PF_FILEMOD_PATHS,
+} probe_func_t;
+
 typedef enum
 {
     SP_IGNORE,
@@ -252,12 +280,16 @@ typedef union
         u64 end;
     } argv;
     tail_call_slot_t tailcall;
-    message_type_t stored_kind;
+    struct {
+        u64 probe_id;
+        message_type_t kind;
+    } stored;
 } error_info_t;
 
 typedef struct
 {
     warning_t code;
+    u64 probe_id;
     message_type_t message_type;
     u64 pid_tgid;
     error_info_t info;

--- a/src/file/delete.h
+++ b/src/file/delete.h
@@ -7,14 +7,9 @@
 #include "common/path.h"
 #include "dentry.h"
 
-static __always_inline void enter_delete(void *ctx)
+static __always_inline incomplete_file_message_t* store_deleted_dentry(struct pt_regs *ctx, void *dentry, u64 probe_id)
 {
-    enter_file_message(ctx, FM_DELETE);
-}
-
-static __always_inline incomplete_file_message_t* store_deleted_dentry(struct pt_regs *ctx, void *dentry)
-{
-    incomplete_file_message_t* event = set_file_dentry(ctx, FM_DELETE, dentry);
+    incomplete_file_message_t* event = set_file_dentry(ctx, FM_DELETE, dentry, probe_id);
     if (event == NULL) return NULL;
 
     // After deletion dentries become "negative" dentries and no
@@ -28,14 +23,14 @@ static __always_inline incomplete_file_message_t* store_deleted_dentry(struct pt
 
  EmitWarning:;
     file_message_t fm = {0};
-    push_file_warning(ctx, &fm, FM_DELETE);
+    push_file_warning(ctx, &fm, FM_DELETE, probe_id);
     return NULL;
 }
 
-static __always_inline void store_deleted_path_dentry(struct pt_regs *ctx, void *path, void *dentry)
+static __always_inline void store_deleted_path_dentry(struct pt_regs *ctx, void *path, void *dentry, u64 probe_id)
 {
-    incomplete_file_message_t* event = store_deleted_dentry(ctx, dentry);
-    set_path_mnt(ctx, event, path);
+    incomplete_file_message_t* event = store_deleted_dentry(ctx, dentry, probe_id);
+    set_path_mnt(ctx, event, path, probe_id);
 }
 
 static __always_inline file_message_t* exit_delete(void *ctx, u64 pid_tgid, incomplete_file_message_t *event)

--- a/src/file/push_file_message.h
+++ b/src/file/push_file_message.h
@@ -35,11 +35,12 @@ static __always_inline int push_flexible_file_message(void *ctx, file_message_t 
 
 // pushes a warning to the process_events perfmap for the current CPU.
 static __always_inline int push_file_warning(void *ctx, file_message_t *fm,
-                                             file_message_type_t fm_type)
+                                             file_message_type_t fm_type, u64 probe_id)
 {
     fm->type = FM_WARNING;
     message_type_t m_type;
     m_type.file = fm_type;
+    fm->u.warning.probe_id = probe_id;
 
     load_warning_info(&fm->u.warning, m_type);
 


### PR DESCRIPTION
`probe_id` is either a syscall number if the probe is a tracepoint; or a custom enum that starts at 0xFFFF with the different kinds of non-tracepoint probes we have for filemod

Additionally, I found a bug in set_current_file_mnt which is used by fchmod where we emit an incorrect warning because we forgot to add a return statement