### PR TITLE
do not emit KIND_MISMATCH errors on the security probes

### DIFF
--- a/src/file/maps.h
+++ b/src/file/maps.h
@@ -114,21 +114,17 @@ static __always_inline incomplete_file_message_t *get_event(void *ctx,
   return event;
 }
 
-static __always_inline incomplete_file_message_t *get_current_event(void *ctx,
-                                                                    file_message_type_t kind, u64 probe_id) {
-  u64 pid_tgid = bpf_get_current_pid_tgid();
-  return get_event(ctx, kind, &pid_tgid, probe_id);
-}
-
 static __always_inline incomplete_file_message_t* set_file_dentry(struct pt_regs *ctx,
                                                                   file_message_type_t kind, void *dentry, u64 probe_id)
 {
-    incomplete_file_message_t* event = get_current_event(ctx, kind, probe_id);
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    incomplete_file_message_t *event = bpf_map_lookup_elem(&incomplete_file_messages, &pid_tgid);
+
     if (event == NULL) return NULL;
     if (event->target_dentry != NULL) return NULL;
+    if (event->kind != kind) return NULL;
 
     event->target_dentry = dentry;
-
     return event;
 }
 


### PR DESCRIPTION
these probes can be called by more than just the syscalls that started the incomplete event. For example, in overlayfs, a modification of a file in the lower system can cause a new directory being created in the upper system. This means that an event we saved through FM_MODIFY will then be attempted to be loaded in a probe that expected FM_CREATE thus emit a warning and drop the valid event. We will now simply skip it if the kind isn't what we expected which matches more our old design of each "kind" being in its own map