### PR TITLE
Use correct magic for BTRFS superblock identification

### DIFF
--- a/src/common/definitions.h
+++ b/src/common/definitions.h
@@ -221,5 +221,4 @@
  * BTRFS Support
  */
 
-/* (btrfs_tree.h) ASCII for _BHRfS_M, no terminating nul */
-#define BTRFS_SB_MAGIC 0x4D5F53665248425F
+#define BTRFS_SB_MAGIC 0x9123683E


### PR DESCRIPTION
#108 introduced correct logic for BTRFS device ID retrieval, but checked superblock magic against the incorrect value (the magic used for disk superblocks). This was missed due to an oversight in testing, and easily corrected.