### PR TITLE
fix bug where symlink wasn't setting the filter_tag on push

### DIFF
--- a/src/file/create.h
+++ b/src/file/create.h
@@ -74,6 +74,7 @@ static __always_inline void _exit_symlink(struct pt_regs *ctx, u64 pid_tgid, inc
     if (cached_path->filter_state <= 0) goto NoEvent; // Didn't match watched path filter
     write_null_char(cursor.buffer, cursor.offset);
     write_string(event->create.source, cursor.buffer, cursor.offset, PATH_MAX);
+    fm->u.action.tag = cached_path->filter_tag;
     push_flexible_file_message(ctx, fm, *cursor.offset);
 
     // lookup tail calls completed; ensure we re-init cached_path next call


### PR DESCRIPTION
When pushing a message about a symlink event, we aren not setting the `filter_tag` field in the message. This means that in userspace, the information about which filemod rule was activated will not be correct. This doesn't affect the actual event or the filtering of the event in kernel-space, but it makes metrics about which rules trigger not accurate.  