### PR TITLE
clean-up in exit_clone for kernel threads

### DIFF
--- a/src/process/clone.h
+++ b/src/process/clone.h
@@ -65,7 +65,7 @@ static __always_inline void exit_clone(void *ctx, pprocess_message_t pm, process
 
   void *ts = (void *)bpf_get_current_task();
   int ret = fill_syscall(&pm->u.syscall_info, ts, pid_tgid >> 32);
-  if (ret > 0) return;
+  if (ret > 0) goto Done;
   if (ret < 0) goto EmitWarning;
 
   pm->type = pm_type;


### PR DESCRIPTION
During the exit probe for `clone_*`-like syscals, if the cloned process is a kernel process then I believe it is possible for the current implementation to not be properly cleaning up the incomplete clone events map because we are returning instead of going to the `Done` clean-up tag. In practice this is not a big deal because the map is an LRU hash at this moment so eventually it'd just age out. I believe I wanted to convert it to not be an LRU hash eventually due to threading issues but that's for another time. 