### PR TITLE
A tracepoint for memfd_create

### DIFF
--- a/src/common/definitions.h
+++ b/src/common/definitions.h
@@ -11,9 +11,8 @@
 
 #define __always_inline	inline __attribute__((always_inline))
 
-#define NAME_MAX                     255 /* # chars in a file name */
-#define PATH_MAX                    4096 /* # chars in a path name including nul */
-#define MFD_NAME_MAX_LEN  (NAME_MAX - 5) /* # chars in a memfd name; NAME-MAX - sizeof("memfd:") + 1 (memfd.c) */
+#define NAME_MAX  255 /* # chars in a file name */
+#define PATH_MAX 4096 /* # chars in a path name including nul */
 
 #define O_ACCMODE	00000003
 #define O_RDONLY	00000000

--- a/src/common/definitions.h
+++ b/src/common/definitions.h
@@ -11,8 +11,9 @@
 
 #define __always_inline	inline __attribute__((always_inline))
 
-#define NAME_MAX         255	/* # chars in a file name */
-#define PATH_MAX        4096	/* # chars in a path name including nul */
+#define NAME_MAX                     255 /* # chars in a file name */
+#define PATH_MAX                    4096 /* # chars in a path name including nul */
+#define MFD_NAME_MAX_LEN  (NAME_MAX - 5) /* # chars in a memfd name; NAME-MAX - sizeof("memfd:") + 1 (memfd.c) */
 
 #define O_ACCMODE	00000003
 #define O_RDONLY	00000000

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -103,6 +103,7 @@ typedef enum
     W_INTERP_MISMATCH,
     W_INTERP_SLOT,
     W_KIND_MISMATCH,
+    W_READ_MEMFD_NAME,
 } warning_t;
 
 typedef enum
@@ -129,6 +130,7 @@ typedef enum
     FM_MODIFY,
     FM_RENAME,
     FM_WARNING,
+    FM_MEMFD_CREATE,
 } file_message_type_t;
 
 typedef union
@@ -340,6 +342,10 @@ typedef struct
         struct {
             file_link_type_t source_link;
         } create;
+        struct {
+            unsigned long flags;
+            int fdno;
+        } memfd_create;
         struct {
             file_ownership_t before_owner;
         } modify;

--- a/src/file-events.c
+++ b/src/file-events.c
@@ -15,6 +15,7 @@
 #include "file/create.h"
 #include "file/delete.h"
 #include "file/maps.h"
+#include "file/memfd.h"
 #include "file/modify.h"
 #include "file/rename.h"
 
@@ -536,6 +537,21 @@ int BPF_KPROBE(security_inode_rename, struct inode *old_dir, struct dentry *old_
 
 /* END RENAME PROBES */
 /* BEGIN OPEN-LIKE PROBES */
+
+SEC("tracepoint/syscalls/sys_enter_memfd_create")
+int sys_enter_memfd_create(struct syscalls_enter_memfd_create_args *ctx)
+{
+    enter_memfd_create(ctx);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_exit_memfd_create")
+int sys_exit_memfd_create(struct syscalls_exit_args *ctx)
+{
+    // exit_memfd pushes the message
+    (void) POP_AND_SETUP(FM_MEMFD_CREATE, exit_memfd);
+    return 0;
+}
 
 SEC("tracepoint/syscalls/sys_enter_open")
 int sys_enter_open(struct syscalls_enter_open_args *ctx)

--- a/src/file-events.c
+++ b/src/file-events.c
@@ -76,7 +76,7 @@ int BPF_KPROBE(security_inode_mkdir, const struct inode *dir, struct dentry *den
 SEC("tracepoint/syscalls/sys_exit_mkdir")
 int sys_exit_mkdir(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP_ARGS(FM_CREATE, exit_create, LINK_NONE);
+    file_message_t *fm = POP_AND_THEN_ARGS(FM_CREATE, exit_create, LINK_NONE);
     finish_message(ctx, fm);
     return 0;
 }
@@ -84,7 +84,7 @@ int sys_exit_mkdir(struct syscalls_exit_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_mkdirat")
 int sys_exit_mkdirat(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP_ARGS(FM_CREATE, exit_create, LINK_NONE);
+    file_message_t *fm = POP_AND_THEN_ARGS(FM_CREATE, exit_create, LINK_NONE);
     finish_message(ctx, fm);
     return 0;
 }
@@ -185,7 +185,7 @@ int BPF_KPROBE(security_inode_link, struct dentry *old_dentry, struct inode *dir
 SEC("tracepoint/syscalls/sys_exit_link")
 int sys_exit_link(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP_ARGS(FM_CREATE, exit_create, LINK_HARD);
+    file_message_t *fm = POP_AND_THEN_ARGS(FM_CREATE, exit_create, LINK_HARD);
     finish_message(ctx, fm);
     return 0;
 }
@@ -193,7 +193,7 @@ int sys_exit_link(struct syscalls_exit_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_linkat")
 int sys_exit_linkat(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP_ARGS(FM_CREATE, exit_create, LINK_HARD);
+    file_message_t *fm = POP_AND_THEN_ARGS(FM_CREATE, exit_create, LINK_HARD);
     finish_message(ctx, fm);
     return 0;
 }
@@ -233,7 +233,7 @@ int BPF_KPROBE(security_inode_create, struct inode *dir, struct dentry *dentry, 
 SEC("tracepoint/syscalls/sys_exit_mknod")
 int sys_exit_mknod(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_MODIFY, exit_modify);
+    file_message_t *fm = POP_AND_THEN(FM_MODIFY, exit_modify);
     finish_message(ctx, fm);
     return 0;
 }
@@ -241,7 +241,7 @@ int sys_exit_mknod(struct syscalls_exit_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_mknodat")
 int sys_exit_mknodat(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_MODIFY, exit_modify);
+    file_message_t *fm = POP_AND_THEN(FM_MODIFY, exit_modify);
     finish_message(ctx, fm);
     return 0;
 }
@@ -260,7 +260,7 @@ int sys_enter_unlink(struct syscalls_enter_generic_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_unlink")
 int sys_exit_unlink(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_DELETE, exit_delete);
+    file_message_t *fm = POP_AND_THEN(FM_DELETE, exit_delete);
     finish_message(ctx, fm);
     return 0;
 }
@@ -275,7 +275,7 @@ int sys_enter_unlinkat(struct syscalls_enter_generic_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_unlinkat")
 int sys_exit_unlinkat(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_DELETE, exit_delete);
+    file_message_t *fm = POP_AND_THEN(FM_DELETE, exit_delete);
     finish_message(ctx, fm);
     return 0;
 }
@@ -318,7 +318,7 @@ int BPF_KPROBE(security_inode_rmdir, struct inode *dir, struct dentry *dentry)
 SEC("tracepoint/syscalls/sys_exit_rmdir")
 int sys_exit_rmdir(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_DELETE, exit_delete);
+    file_message_t *fm = POP_AND_THEN(FM_DELETE, exit_delete);
     finish_message(ctx, fm);
     return 0;
 }
@@ -359,7 +359,7 @@ int sys_enter_chmod(struct syscalls_enter_generic_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_chmod")
 int sys_exit_chmod(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_MODIFY, exit_modify);
+    file_message_t *fm = POP_AND_THEN(FM_MODIFY, exit_modify);
     finish_message(ctx, fm);
     return 0;
 }
@@ -374,7 +374,7 @@ int sys_enter_fchmod(struct syscalls_enter_generic_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_fchmod")
 int sys_exit_fchmod(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_MODIFY, exit_modify);
+    file_message_t *fm = POP_AND_THEN(FM_MODIFY, exit_modify);
     finish_message(ctx, fm);
     return 0;
 }
@@ -389,7 +389,7 @@ int sys_enter_fchmodat(struct syscalls_enter_generic_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_fchmodat")
 int sys_exit_fchmodat(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_MODIFY, exit_modify);
+    file_message_t *fm = POP_AND_THEN(FM_MODIFY, exit_modify);
     finish_message(ctx, fm);
     return 0;
 }
@@ -415,7 +415,7 @@ int sys_enter_chown(struct syscalls_enter_generic_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_chown")
 int sys_exit_chown(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_MODIFY, exit_modify);
+    file_message_t *fm = POP_AND_THEN(FM_MODIFY, exit_modify);
     finish_message(ctx, fm);
     return 0;
 }
@@ -430,7 +430,7 @@ int sys_enter_lchown(struct syscalls_enter_generic_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_lchown")
 int sys_exit_lchown(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_MODIFY, exit_modify);
+    file_message_t *fm = POP_AND_THEN(FM_MODIFY, exit_modify);
     finish_message(ctx, fm);
     return 0;
 }
@@ -445,7 +445,7 @@ int sys_enter_fchown(struct syscalls_enter_generic_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_fchown")
 int sys_exit_fchown(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_MODIFY, exit_modify);
+    file_message_t *fm = POP_AND_THEN(FM_MODIFY, exit_modify);
     finish_message(ctx, fm);
     return 0;
 }
@@ -460,7 +460,7 @@ int sys_enter_fchownat(struct syscalls_enter_generic_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_fchownat")
 int sys_exit_fchownat(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_MODIFY, exit_modify);
+    file_message_t *fm = POP_AND_THEN(FM_MODIFY, exit_modify);
     finish_message(ctx, fm);
     return 0;
 }
@@ -486,7 +486,7 @@ int sys_enter_rename(struct syscalls_enter_generic_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_rename")
 int sys_exit_rename(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_RENAME, exit_rename);
+    file_message_t *fm = POP_AND_THEN(FM_RENAME, exit_rename);
     finish_message(ctx, fm);
     return 0;
 }
@@ -501,7 +501,7 @@ int sys_enter_renameat(struct syscalls_enter_generic_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_renameat")
 int sys_exit_renameat(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_RENAME, exit_rename);
+    file_message_t *fm = POP_AND_THEN(FM_RENAME, exit_rename);
     finish_message(ctx, fm);
     return 0;
 }
@@ -516,7 +516,7 @@ int sys_enter_renameat2(struct syscalls_enter_generic_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_renameat2")
 int sys_exit_renameat2(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_RENAME, exit_rename);
+    file_message_t *fm = POP_AND_THEN(FM_RENAME, exit_rename);
     finish_message(ctx, fm);
     return 0;
 }
@@ -549,7 +549,7 @@ SEC("tracepoint/syscalls/sys_exit_memfd_create")
 int sys_exit_memfd_create(struct syscalls_exit_args *ctx)
 {
     // exit_memfd pushes the message
-    (void) POP_AND_SETUP(FM_MEMFD_CREATE, exit_memfd);
+    (void) POP_AND_THEN(FM_MEMFD_CREATE, exit_memfd);
     return 0;
 }
 
@@ -607,7 +607,7 @@ int BPF_KPROBE(security_file_open, void *file)
 SEC("tracepoint/syscalls/sys_exit_open")
 int sys_exit_open(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_MODIFY, exit_modify);
+    file_message_t *fm = POP_AND_THEN(FM_MODIFY, exit_modify);
     finish_message(ctx, fm);
     return 0;
 }
@@ -615,7 +615,7 @@ int sys_exit_open(struct syscalls_exit_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_openat")
 int sys_exit_openat(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_MODIFY, exit_modify);
+    file_message_t *fm = POP_AND_THEN(FM_MODIFY, exit_modify);
     finish_message(ctx, fm);
     return 0;
 }
@@ -623,7 +623,7 @@ int sys_exit_openat(struct syscalls_exit_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_openat2")
 int sys_exit_openat2(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_MODIFY, exit_modify);
+    file_message_t *fm = POP_AND_THEN(FM_MODIFY, exit_modify);
     finish_message(ctx, fm);
     return 0;
 }
@@ -631,7 +631,7 @@ int sys_exit_openat2(struct syscalls_exit_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_open_by_handle_at")
 int sys_exit_open_by_handle_at(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_MODIFY, exit_modify);
+    file_message_t *fm = POP_AND_THEN(FM_MODIFY, exit_modify);
     finish_message(ctx, fm);
     return 0;
 }
@@ -649,7 +649,7 @@ int sys_enter_creat(struct syscalls_enter_generic_args *ctx)
 SEC("tracepoint/syscalls/sys_exit_creat")
 int sys_exit_creat(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_MODIFY, exit_modify);
+    file_message_t *fm = POP_AND_THEN(FM_MODIFY, exit_modify);
     finish_message(ctx, fm);
     return 0;
 }
@@ -671,7 +671,7 @@ int BPF_KPROBE(security_path_truncate, const struct path *path)
 SEC("tracepoint/syscalls/sys_exit_truncate")
 int sys_exit_truncate(struct syscalls_exit_args *ctx)
 {
-    file_message_t *fm = POP_AND_SETUP(FM_MODIFY, exit_modify);
+    file_message_t *fm = POP_AND_THEN(FM_MODIFY, exit_modify);
     finish_message(ctx, fm);
     return 0;
 }

--- a/src/file/maps.h
+++ b/src/file/maps.h
@@ -28,6 +28,10 @@ typedef struct {
             void *source;           // dentry for hard link, char for symlink, NULL otherwise
         } create;
         struct {
+            unsigned long flags;   // Flags passed to memfd_create (or memfd_secret)
+            const char* uname;     // Informative name of the memfd if available. memfd_create limits this to 249+1 bytes.
+        } memfd_create;
+        struct {
             file_ownership_t ownership; // ownership data prior to inode deletion
             file_info_t target;         // target info prior to inode deletion
         } delete;
@@ -55,25 +59,29 @@ struct bpf_map_def SEC("maps/incomplete_file_messages") incomplete_file_messages
     .namespace = "",
 };
 
-static __always_inline void enter_file_message(struct syscalls_enter_generic_args *ctx, file_message_type_t kind)
+static __always_inline void prepare_file_message(struct syscalls_enter_generic_args* ctx, file_message_type_t kind, incomplete_file_message_t* event)
+{
+    *event = (incomplete_file_message_t){0};
+
+    event->start_ktime_ns = bpf_ktime_get_ns();
+    event->kind = kind;
+    event->probe_id = ctx->__syscall_nr;
+}
+
+static __always_inline void try_insert_incomplete_file_message(struct syscalls_enter_generic_args* ctx, incomplete_file_message_t* event)
 {
     u64 pid_tgid = bpf_get_current_pid_tgid();
-    incomplete_file_message_t event = {0};
-    event.start_ktime_ns = bpf_ktime_get_ns();
-    event.kind = kind;
-    event.probe_id = ctx->__syscall_nr;
 
     // deliberately only insert if the key does not exist -- we want
     // to be truthful if we forgot to pop so userspace knows that
     // there is a bug somewhere
-    int ret = bpf_map_update_elem(&incomplete_file_messages, &pid_tgid, &event, BPF_NOEXIST);
-    if (ret < 0)
-    {
+    int ret = bpf_map_update_elem(&incomplete_file_messages, &pid_tgid, event, BPF_NOEXIST);
+    if (ret < 0) {
         file_message_t fm = {0};
         fm.type = FM_WARNING;
         fm.u.warning.probe_id = ctx->__syscall_nr;
         fm.u.warning.pid_tgid = pid_tgid;
-        fm.u.warning.message_type.file = kind;
+        fm.u.warning.message_type.file = event->kind;
         fm.u.warning.code = W_UPDATE_MAP_ERROR;
         fm.u.warning.info.err = ret;
 
@@ -83,6 +91,13 @@ static __always_inline void enter_file_message(struct syscalls_enter_generic_arg
         // accidentally try to use it to re-emit the event
         bpf_map_delete_elem(&incomplete_file_messages, &pid_tgid);
     }
+}
+
+static __always_inline void enter_file_message(struct syscalls_enter_generic_args *ctx, file_message_type_t kind)
+{
+    incomplete_file_message_t event = {0};
+    prepare_file_message(ctx, kind, &event);
+    try_insert_incomplete_file_message(ctx, &event);
 }
 
 static __always_inline incomplete_file_message_t *get_event(void *ctx,

--- a/src/file/maps.h
+++ b/src/file/maps.h
@@ -205,7 +205,7 @@ EmitWarning:;
     if (ctx->ret < 0) goto Pop;
 
 // Returns a file_message_event_t* and handles the popping from the incomplete map
-#define POP_AND_SETUP(kind, fn)                                         \
+#define POP_AND_THEN(kind, fn)                                         \
     ({                                                                  \
         GET_EXIT_EVENT(kind)                                            \
         ret = fn(ctx, pid_tgid, event);                                 \
@@ -216,7 +216,7 @@ EmitWarning:;
     })
 
 // Returns a file_message_event_t* and handles the popping from the incomplete map
-#define POP_AND_SETUP_ARGS(kind, fn, args...)                           \
+#define POP_AND_THEN_ARGS(kind, fn, args...)                           \
     ({                                                                  \
         GET_EXIT_EVENT(kind)                                            \
         ret = fn(ctx, pid_tgid, event, args);                           \

--- a/src/file/memfd.h
+++ b/src/file/memfd.h
@@ -7,6 +7,11 @@
 
 #include "common/definitions.h"
 
+static const char MEMFD_PREFIX[] = "memfd:";
+
+#define MEMFD_PREFIX_LEN sizeof(MEMFD_PREFIX) - 1
+const unsigned long MEMFD_NAME_MAX = NAME_MAX - MEMFD_PREFIX_LEN;
+
 static __always_inline void enter_memfd_create(struct syscalls_enter_memfd_create_args *ctx)
 {
     incomplete_file_message_t event = {0};
@@ -34,20 +39,23 @@ static __always_inline file_message_t* exit_memfd(struct syscalls_exit_args *ctx
     fm->u.action.u.memfd_create.fdno = ctx->ret;
     fm->u.action.buffer_len = sizeof(file_message_t);
 
-    // if present, write the memfd's name into the string buffer.
+    char* name_buf = (void*)buffer + sizeof(file_message_t);
+    __builtin_memcpy_inline(name_buf, MEMFD_PREFIX, MEMFD_PREFIX_LEN);
+    name_buf += MEMFD_PREFIX_LEN;
+
+    long read_len = 0;
     if (event->memfd_create.uname != NULL) {
         // note that the name as read is the name passed by the caller, without
         // the `memfd:` prepended by the kernel.
-        char* name_buf = (void*)buffer + sizeof(file_message_t);
-        long ret = bpf_probe_read_user_str(name_buf, MFD_NAME_MAX_LEN+1, event->memfd_create.uname);
-        if (ret < 0) {
+        read_len = bpf_probe_read_user_str(name_buf, MEMFD_NAME_MAX, event->memfd_create.uname);
+        if (read_len < 0) {
             file_message_t fm = {0};
             fm.type = FM_WARNING;
             fm.u.warning.probe_id = ctx->__syscall_nr;
             fm.u.warning.pid_tgid = bpf_get_current_pid_tgid();
             fm.u.warning.message_type.file = FM_MEMFD_CREATE;
             fm.u.warning.code = W_READ_MEMFD_NAME;
-            fm.u.warning.info.err = ret;
+            fm.u.warning.info.err = read_len;
 
             push_file_message((struct syscalls_enter_generic_args *)ctx, &fm);
 
@@ -55,11 +63,12 @@ static __always_inline file_message_t* exit_memfd(struct syscalls_exit_args *ctx
             // function. ensure that there isn't an unterminated string in the
             // buffer as the result of the failed read.
             name_buf[0] = (char)0;
-            ret = 0;
-        }
 
-        fm->u.action.buffer_len += ret;
+            read_len = 0;
+        }
     }
+
+    fm->u.action.buffer_len += read_len + MEMFD_PREFIX_LEN;
 
     push_flexible_file_message(ctx, fm, fm->u.action.buffer_len);
 

--- a/src/file/memfd.h
+++ b/src/file/memfd.h
@@ -8,10 +8,10 @@
 #include "common/definitions.h"
 
 struct syscalls_enter_memfd_create_args {
-   __u64 unused;
-   long __syscall_nr;
-   const char *uname;
-   unsigned long flags;
+    __u64 unused;
+    long __syscall_nr;
+    const char *uname;
+    unsigned long flags;
 };
 
 static const char MEMFD_PREFIX[] = "memfd:";

--- a/src/file/memfd.h
+++ b/src/file/memfd.h
@@ -1,0 +1,67 @@
+#include "maps.h"
+#include "modify.h"
+#include "push_file_message.h"
+#include "vmlinux.h"
+
+#include "common/definitions.h"
+
+static __always_inline void enter_memfd_create(struct syscalls_enter_memfd_create_args *ctx)
+{
+    incomplete_file_message_t event = {0};
+
+    // syscalls_enter_memfd_create_args is a superset of syscalls_enter_generic_args
+    prepare_file_message((struct syscalls_enter_generic_args *)ctx, FM_MEMFD_CREATE, &event);
+
+    event.memfd_create.flags = ctx->flags;
+    event.memfd_create.uname = ctx->uname;
+
+    try_insert_incomplete_file_message((struct syscalls_enter_generic_args*)ctx, &event);
+}
+
+static __always_inline file_message_t* exit_memfd(struct syscalls_exit_args *ctx, u64 pid_tgid, incomplete_file_message_t* event) {
+    u32 key = 0;
+    buf_t *buffer = (buf_t *)bpf_map_lookup_elem(&buffers, &key);
+    if (buffer == NULL) return NULL;
+
+    file_message_t *fm = (file_message_t *)buffer;
+
+    fm->type = event->kind;
+    fm->u.action.pid = pid_tgid >> 32;
+    fm->u.action.mono_ns = event->start_ktime_ns;
+    fm->u.action.u.memfd_create.flags = event->memfd_create.flags;
+    fm->u.action.u.memfd_create.fdno = ctx->ret;
+    fm->u.action.buffer_len = sizeof(file_message_t);
+
+    u64 dynamic_size = sizeof(file_message_t); 
+
+    // if present, write the memfd's name into the string buffer.
+    if (event->memfd_create.uname != NULL) {
+        // note that the name as read is the name passed by the caller, without
+        // the `memfd:` prepended by the kernel.
+        char* name_buf = (void*)buffer + dynamic_size;
+        long ret = bpf_probe_read_user_str(name_buf, MFD_NAME_MAX_LEN+1, event->memfd_create.uname);
+        if (ret < 0) {
+            file_message_t fm = {0};
+            fm.type = FM_WARNING;
+            fm.u.warning.probe_id = ctx->__syscall_nr;
+            fm.u.warning.pid_tgid = bpf_get_current_pid_tgid();
+            fm.u.warning.message_type.file = FM_MEMFD_CREATE;
+            fm.u.warning.code = W_READ_MEMFD_NAME;
+            fm.u.warning.info.err = ret;
+
+            push_file_message((struct syscalls_enter_generic_args *)ctx, &fm);
+
+            // this should not be fatal. the name is informative, but has no
+            // function. ensure that there isn't an unterminated string in the
+            // buffer as the result of the failed read.
+            name_buf[0] = (char)0;
+        }
+
+        dynamic_size += ret;
+    }
+
+    push_flexible_file_message(ctx, fm, dynamic_size);
+
+    // to reuse POP_AND_SETUP this function needs declare a file_message_t* return type
+    return NULL;
+}

--- a/src/file/memfd.h
+++ b/src/file/memfd.h
@@ -72,6 +72,6 @@ static __always_inline file_message_t* exit_memfd(struct syscalls_exit_args *ctx
 
     push_flexible_file_message(ctx, fm, fm->u.action.buffer_len);
 
-    // to reuse POP_AND_SETUP this function needs declare a file_message_t* return type
+    // to reuse POP_AND_THEN this function needs declare a file_message_t* return type
     return NULL;
 }

--- a/src/file/memfd.h
+++ b/src/file/memfd.h
@@ -2,11 +2,17 @@
 #include "common/bpf_helpers.h"
 #include "common/types.h"
 #include "maps.h"
-#include "modify.h"
 #include "push_file_message.h"
 #include "vmlinux.h"
 
 #include "common/definitions.h"
+
+struct syscalls_enter_memfd_create_args {
+   __u64 unused;
+   long __syscall_nr;
+   const char *uname;
+   unsigned long flags;
+};
 
 static const char MEMFD_PREFIX[] = "memfd:";
 

--- a/src/file/memfd.h
+++ b/src/file/memfd.h
@@ -1,3 +1,5 @@
+#include "common/bpf_helpers.h"
+#include "common/types.h"
 #include "maps.h"
 #include "modify.h"
 #include "push_file_message.h"
@@ -32,13 +34,11 @@ static __always_inline file_message_t* exit_memfd(struct syscalls_exit_args *ctx
     fm->u.action.u.memfd_create.fdno = ctx->ret;
     fm->u.action.buffer_len = sizeof(file_message_t);
 
-    u64 dynamic_size = sizeof(file_message_t); 
-
     // if present, write the memfd's name into the string buffer.
     if (event->memfd_create.uname != NULL) {
         // note that the name as read is the name passed by the caller, without
         // the `memfd:` prepended by the kernel.
-        char* name_buf = (void*)buffer + dynamic_size;
+        char* name_buf = (void*)buffer + sizeof(file_message_t);
         long ret = bpf_probe_read_user_str(name_buf, MFD_NAME_MAX_LEN+1, event->memfd_create.uname);
         if (ret < 0) {
             file_message_t fm = {0};
@@ -55,12 +55,13 @@ static __always_inline file_message_t* exit_memfd(struct syscalls_exit_args *ctx
             // function. ensure that there isn't an unterminated string in the
             // buffer as the result of the failed read.
             name_buf[0] = (char)0;
+            ret = 0;
         }
 
-        dynamic_size += ret;
+        fm->u.action.buffer_len += ret;
     }
 
-    push_flexible_file_message(ctx, fm, dynamic_size);
+    push_flexible_file_message(ctx, fm, fm->u.action.buffer_len);
 
     // to reuse POP_AND_SETUP this function needs declare a file_message_t* return type
     return NULL;

--- a/src/file/memfd.h
+++ b/src/file/memfd.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "common/bpf_helpers.h"
 #include "common/types.h"
 #include "maps.h"
@@ -9,8 +10,8 @@
 
 static const char MEMFD_PREFIX[] = "memfd:";
 
-#define MEMFD_PREFIX_LEN sizeof(MEMFD_PREFIX) - 1
-const unsigned long MEMFD_NAME_MAX = NAME_MAX - MEMFD_PREFIX_LEN;
+#define MEMFD_PREFIX_LEN (sizeof(MEMFD_PREFIX) - 1)
+static const unsigned long MEMFD_NAME_MAX = NAME_MAX - MEMFD_PREFIX_LEN;
 
 static __always_inline void enter_memfd_create(struct syscalls_enter_memfd_create_args *ctx)
 {

--- a/src/file/open.h
+++ b/src/file/open.h
@@ -2,13 +2,6 @@
 
 #include "common/definitions.h"
 
-struct syscalls_enter_memfd_create_args {
-   __u64 unused;
-   long __syscall_nr;
-   const char *uname;
-   unsigned long flags;
-};
-
 struct syscalls_enter_open_args {
     __u64 unused;
     long __syscall_nr;

--- a/src/file/open.h
+++ b/src/file/open.h
@@ -2,6 +2,13 @@
 
 #include "common/definitions.h"
 
+struct syscalls_enter_memfd_create_args {
+   __u64 unused;
+   long __syscall_nr;
+   const char *uname;
+   unsigned long flags;
+};
+
 struct syscalls_enter_open_args {
     __u64 unused;
     long __syscall_nr;


### PR DESCRIPTION
Add a tracepoint and new file message variant to capture details about `memfd_create`. 

For compatibility reasons, the underlying inode and name as the kernel sees it are not retrieved. This is something we can improve with CORE.