### PR TITLE
send discard events for incomplete script events

### DIFF
--- a/src/common/types.h
+++ b/src/common/types.h
@@ -120,6 +120,7 @@ typedef enum
     PM_EXECVEAT,
     PM_WARNING,
     PM_SCRIPT,
+    PM_DISCARD,
 } process_message_type_t;
 
 typedef enum
@@ -304,11 +305,17 @@ typedef struct
     file_info_t scripts[4];
 } script_info_t;
 
+typedef struct
+{
+    u64 event_id;
+} discard_info_t;
+
 typedef union
 {
     syscall_info_t syscall_info;
     warning_info_t warning_info;
     script_info_t script_info;
+    discard_info_t discard_info;
 } process_message_data_t;
 
 typedef struct

--- a/src/process/exec.h
+++ b/src/process/exec.h
@@ -40,7 +40,14 @@ static __always_inline void exit_exec(struct pt_regs *ctx, process_message_type_
 
     // do not emit if we couldn't fill the syscall info
     ret = fill_syscall(&pm->u.syscall_info, ts, pid_tgid >> 32);
-    if (ret > 0) return; // TODO: send discard event if pm->u.syscall_info.data.exec_info.event_id != 0?
+    if (ret > 0) {
+        // not a qualifying exec (kernel thread, or offsets not yet loaded). Silent skip,
+        // matching the original behavior — but if push_scripts already emitted a PM_SCRIPT
+        // we still need to tell userspace to drop the orphan.
+        u64 event_id = pm->u.syscall_info.data.exec_info.event_id;
+        if (event_id != 0) push_discard(ctx, pm, event_id);
+        return;
+    }
     if (ret < 0) goto EmitWarning;
 
     void *mmptr = read_field_ptr(ts, CRC_TASK_STRUCT_MM);
@@ -168,9 +175,15 @@ static __always_inline void exit_exec(struct pt_regs *ctx, process_message_type_
     error_info_t info = {0};
     info.tailcall = tail_call;
     set_local_warning(W_TAIL_CALL_MAX, info);
+    // manually emit the warning rather than calling for EmitWarning as that also sends a discard
+    cached_path->next_dentry = NULL;
+    push_warning(ctx, pm, pm_type);
+    return;
 
  EmitWarning:;
-    // TODO: send discard event if pm->u.syscall_info.data.exec_info.event_id != 0?
+    // an error occurred so if we pushed a script let's send a discard event now
+    u64 event_id = pm->u.syscall_info.data.exec_info.event_id;
+    if (event_id != 0) push_discard(ctx, pm, event_id);
     cached_path->next_dentry = NULL;
 
     push_warning(ctx, pm, pm_type);

--- a/src/process/push_message.h
+++ b/src/process/push_message.h
@@ -45,3 +45,12 @@ static __always_inline int push_warning(void *ctx, pprocess_message_t pm,
 
     return push_message(ctx, pm);
 }
+
+// Pushes a discard message for an incomplete event (e.g., a script event where we couldn't emit the
+// exec event)
+static __always_inline int push_discard(void *ctx, pprocess_message_t pm, u64 event_id)
+{
+    pm->type = PM_DISCARD;
+    pm->u.discard_info.event_id = event_id;
+    return push_message(ctx, pm);
+}


### PR DESCRIPTION
When processing `script` events, we send two separate events to userspace but an error can occur in-between them. In teh case an error occurs in between them let's send a discard event so userspace knows not to wait for the final exec event. 